### PR TITLE
PartyBots behavioral improvements

### DIFF
--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -913,8 +913,18 @@ void PartyBotAI::UpdateAI(uint32 const diff)
         {
             if (!m_isStaying)
             {
-                if (me->GetMotionMaster()->GetCurrentMovementGeneratorType() != FOLLOW_MOTION_TYPE)
-                    me->GetMotionMaster()->MoveFollow(pLeader, urand(PB_MIN_FOLLOW_DIST, PB_MAX_FOLLOW_DIST), frand(PB_MIN_FOLLOW_ANGLE, PB_MAX_FOLLOW_ANGLE));
+                if (GetRole() == ROLE_HEALER && pLeader->GetVictim() && me->IsWithinDistInMap(pLeader, 10.0f))
+                {
+                    if (RunAwayFromTarget(pLeader->GetVictim()))
+                        me->GetMotionMaster()->MoveFollow(pLeader, 25.0f, frand(PB_MIN_FOLLOW_ANGLE, PB_MAX_FOLLOW_ANGLE));
+                        return;
+                }
+                else
+                {
+                    if (me->GetMotionMaster()->GetCurrentMovementGeneratorType() != FOLLOW_MOTION_TYPE)
+                        me->GetMotionMaster()->MoveFollow(pLeader, urand(PB_MIN_FOLLOW_DIST, PB_MAX_FOLLOW_DIST), frand(PB_MIN_FOLLOW_ANGLE, PB_MAX_FOLLOW_ANGLE));
+                }
+                
             }
         }
         else
@@ -935,7 +945,7 @@ void PartyBotAI::UpdateAI(uint32 const diff)
                         float chaseDistance = isMeleeDpsOrTank ? 0.0f : 25.0f;
                         if (!isMeleeDpsOrTank)
                             me->SetCasterChaseDistance(chaseDistance);
-                            
+
                         me->GetMotionMaster()->MoveChase(pVictim, chaseDistance);
                         break;
                 }

--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -749,22 +749,22 @@ void PartyBotAI::UpdateAI(uint32 const diff)
         }
         else
         {
-            if (ShouldAutoRevive())
-            {
-                me->ResurrectPlayer(0.5f);
-                me->SpawnCorpseBones();
-                me->CastSpell(me, PB_SPELL_HONORLESS_TARGET, true);
-                return;
-            }
-
             if(ShouldReviveWithOwner() && !pLeader->IsDead())
             {
                 me->ResurrectPlayer(0.5f);
                 me->SpawnCorpseBones();
                 me->CastSpell(me, PB_SPELL_HONORLESS_TARGET, true);
                 float x, y, z;
-                pLeader->GetNearPoint(pLeader, x, y, z, 0, frand(3.0f, 5.0f), frand(3.0f, 5.0f));
+                pLeader->GetNearPoint(pLeader, x, y, z, 0, frand(5.0f, 8.0f), frand(0.0f, 3.0f));
                 me->TeleportTo(pLeader->GetMapId(), x, y, z, pLeader->GetOrientation());
+                return;
+            }
+
+            if (ShouldAutoRevive())
+            {
+                me->ResurrectPlayer(0.5f);
+                me->SpawnCorpseBones();
+                me->CastSpell(me, PB_SPELL_HONORLESS_TARGET, true);
                 return;
             }
         }
@@ -931,7 +931,12 @@ void PartyBotAI::UpdateAI(uint32 const diff)
                 {
                     case IDLE_MOTION_TYPE:
                     case FOLLOW_MOTION_TYPE:
-                        me->GetMotionMaster()->MoveChase(pVictim);
+                        bool isMeleeDpsOrTank = (GetRole() == ROLE_MELEE_DPS || GetRole() == ROLE_TANK);
+                        float chaseDistance = isMeleeDpsOrTank ? 0.0f : 25.0f;
+                        if (!isMeleeDpsOrTank)
+                            me->SetCasterChaseDistance(chaseDistance);
+                            
+                        me->GetMotionMaster()->MoveChase(pVictim, chaseDistance);
                         break;
                 }
             }
@@ -3572,7 +3577,7 @@ void PartyBotAI::RepositionMeleeDps()
             
             // Update the ground position and move to the new position
             me->UpdateGroundPositionZ(newX, newY, newZ);
-            me->GetMotionMaster()->MovePoint(0, newX, newY, newZ, MOVE_PATHFINDING | MOVE_RUN | MOVE_EXCLUDE_STEEP_SLOPES);
+            me->GetMotionMaster()->MovePoint(0, newX, newY, newZ, MOVE_PATHFINDING | MOVE_RUN | MOVE_EXCLUDE_STEEP_SLOPES, 0.0f, me->GetAngle(pVictim));
         }
     }
 }

--- a/src/game/PlayerBots/PlayerBotMgr.cpp
+++ b/src/game/PlayerBots/PlayerBotMgr.cpp
@@ -1146,9 +1146,16 @@ bool PlayerBotMgr::CloneOfflinePlayer(Player* pPlayer, ObjectGuid guid)
 
 bool ChatHandler::HandlePartyBotCloneCommand(char* args)
 {
+    
     Player* pPlayer = GetSession()->GetPlayer();
     if (!pPlayer)
         return false;
+
+    // Must be resting or inside dungeon to summon bot
+    if (!pPlayer->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_RESTING) && !pPlayer->GetMap()->IsDungeon()) {
+        SendSysMessage("You must be resting or inside a dungeon to summon bots.");
+        return false;
+    }
 
     Player* pTarget = nullptr;
 


### PR DESCRIPTION
- Bots will now check whether or not they should revive when their owner revives before they check whether or not they should auto-revive. (To prevent them from auto-ressurecting due to proximity when no healer class is in the group)

- Clone command will now correctly enforce the Lavender Dreams bot summoning restrictions

- Modified bots' movement logic: ranged DPS and healers will no longer chase the mob. (This was previously fixed in `AttackStart` only, but now applies to all conditions

- Fixed melee DPS repositioning logic to set the final orientation after moving to their destination

- Improved healer positioning logic