### PR TITLE
Introducing PartyBotChat

### DIFF
--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -192,6 +192,7 @@ set (game_SRCS
     PacketBroadcast/MovementBroadcaster.cpp
     PacketBroadcast/PlayerBroadcaster.cpp
     PlayerBots/PartyBotAI.cpp
+    PlayerBots/PartyBotChat.cpp
     PlayerBots/PartyBotEncounters.cpp
     PlayerBots/Encounters/MoltenCore.cpp
     PlayerBots/CombatBotBaseAI.cpp

--- a/src/game/Handlers/ChatHandler.cpp
+++ b/src/game/Handlers/ChatHandler.cpp
@@ -40,6 +40,7 @@
 #include "CellImpl.h"
 #include "Anticheat.h"
 #include "AccountMgr.h"
+#include "PlayerBots/PartyBotChat.h"
 
 bool WorldSession::CheckChatMessageValidity(char* msg, uint32 lang, uint32 msgType)
 {
@@ -551,7 +552,10 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket& recv_data)
             ChatHandler::BuildChatPacket(data, ChatMsg(type), msg, Language(lang), _player->GetChatTag(), _player->GetObjectGuid(), _player->GetName());
             group->BroadcastPacket(&data, false, group->GetMemberGroup(GetPlayer()->GetObjectGuid()));
             if (lang != LANG_ADDON)
+            {
                 sWorld.LogChat(this, "Group", msg, nullptr, group->GetId());
+                PartyBotChat::GetInstance()->OnPacketReceived(&data);
+            } 
         }
         break;
         case CHAT_MSG_GUILD: // Master side

--- a/src/game/PlayerBots/Encounters/MoltenCore.cpp
+++ b/src/game/PlayerBots/Encounters/MoltenCore.cpp
@@ -29,40 +29,59 @@ bool PartyBotEncounters_MC::HandleEncounterAI(PartyBotAI* pBot)
     uint32 majordomoState = pInstance->GetData(TYPE_MAJORDOMO);
     uint32 ragnarosState  = pInstance->GetData(TYPE_RAGNAROS);
 
+    // Check if any encounter is in progress
+    bool anyEncounterInProgress = 
+        (lucifronState == IN_PROGRESS) ||
+        (magmadarState == IN_PROGRESS) ||
+        (gehennasState == IN_PROGRESS) ||
+        (garrState == IN_PROGRESS) ||
+        (geddonState == IN_PROGRESS) ||
+        (shazzrahState == IN_PROGRESS) ||
+        (sulfuronState == IN_PROGRESS) ||
+        (golemaggState == IN_PROGRESS) ||
+        (majordomoState == IN_PROGRESS) ||
+        (ragnarosState == IN_PROGRESS || ragnarosState == SPECIAL);
+
+    if (!anyEncounterInProgress)
+    {
+        m_overrideMeleePosition = false;
+        m_overrideMagicDispel = false;
+        return true;
+    }
     
-    if (lucifronState == IN_PROGRESS || lucifronState == SPECIAL)
+    if (lucifronState == IN_PROGRESS)
     {
         return LucifronEncounter(pBot);
     }
-    else if (magmadarState == IN_PROGRESS || magmadarState == SPECIAL)
+    else if (magmadarState == IN_PROGRESS)
     {
         return MagmadarEncounter(pBot);
     }
-    else if (gehennasState == IN_PROGRESS || gehennasState == SPECIAL)
+    else if (gehennasState == IN_PROGRESS)
     {
         return GehennasEncounter(pBot);
     }
-    else if (garrState == IN_PROGRESS || garrState == SPECIAL)
+    else if (garrState == IN_PROGRESS)
     {
         return GarrEncounter(pBot);
     }
-    else if (geddonState == IN_PROGRESS || geddonState == SPECIAL)
+    else if (geddonState == IN_PROGRESS)
     {
         return GeddonEncounter(pBot);
     }
-    else if (shazzrahState == IN_PROGRESS || shazzrahState == SPECIAL)
+    else if (shazzrahState == IN_PROGRESS)
     {
         return ShazzrahEncounter(pBot);
     }
-    else if (sulfuronState == IN_PROGRESS || sulfuronState == SPECIAL)
+    else if (sulfuronState == IN_PROGRESS)
     {
         return SulfuronEncounter(pBot);
     }
-    else if (golemaggState == IN_PROGRESS || golemaggState == SPECIAL)
+    else if (golemaggState == IN_PROGRESS)
     {
         return GolemaggEncounter(pBot);
     }
-    else if (majordomoState == IN_PROGRESS || majordomoState == SPECIAL)
+    else if (majordomoState == IN_PROGRESS)
     {
         return MajordomoEncounter(pBot);
     }
@@ -70,7 +89,6 @@ bool PartyBotEncounters_MC::HandleEncounterAI(PartyBotAI* pBot)
     {
         return RagnarosEncounter(pBot);
     }
-
 
     return true;
 }

--- a/src/game/PlayerBots/Encounters/MoltenCore.cpp
+++ b/src/game/PlayerBots/Encounters/MoltenCore.cpp
@@ -1,4 +1,5 @@
 #include "MoltenCore.h"
+#include "Spells/SpellAuras.h"
 
 #ifndef M_PI_2
 #define M_PI_2 1.57079632679489661923
@@ -7,6 +8,24 @@
 #define SPELL_DISPEL_MAGIC 988
 #define SPELL_AURA_MOD_DECREASE_HEALTH 4
 #define SPELL_AURA_MOD_DECREASE_SPEED 139
+#define SPELL_LIVINGBOMB 20475
+#define SPELL_INFERNO 19695
+
+#define BARON_GEDDON 12056
+
+bool PartyBotEncounters_MC::AnnouncedLivingBomb = false;
+bool PartyBotEncounters_MC::BaronGeddonInferno = false;
+Player* PartyBotEncounters_MC::LivingBombTarget = nullptr;
+uint32 PartyBotEncounters_MC::LastInsultedTime = 0;
+
+void PartyBotEncounters_MC::ResetEncounterVars()
+{
+    m_overrideMeleePosition = false;
+    m_overrideMagicDispel = false;
+    AnnouncedLivingBomb = false;
+    LivingBombTarget = nullptr;
+    LastInsultedTime = 0;
+}
 
 bool PartyBotEncounters_MC::HandleEncounterAI(PartyBotAI* pBot)
 {
@@ -43,11 +62,7 @@ bool PartyBotEncounters_MC::HandleEncounterAI(PartyBotAI* pBot)
         (ragnarosState == IN_PROGRESS || ragnarosState == SPECIAL);
 
     if (!anyEncounterInProgress)
-    {
-        m_overrideMeleePosition = false;
-        m_overrideMagicDispel = false;
-        return true;
-    }
+        ResetEncounterVars();
     
     if (lucifronState == IN_PROGRESS)
     {
@@ -339,33 +354,164 @@ bool PartyBotEncounters_MC::GeddonEncounter(PartyBotAI* pBot)
     if (!pPlayer)
         return true;
 
-    if (Unit* pVictim = pPlayer->GetVictim())
+    if (pPlayer->IsMoving() && !BaronGeddonInferno)
+        return false;
+    
+    if (pPlayer->HasAura(SPELL_LIVINGBOMB))
     {
-        // If bombed, run away from party
-        if (pPlayer->HasAuraType(SPELL_AURA_PERIODIC_TRIGGER_SPELL))
+        uint32 timeLeft = pPlayer->GetSpellAuraHolder(SPELL_LIVINGBOMB)->GetAuraDuration();
+        
+        LivingBombTarget = pPlayer;
+
+        if (!AnnouncedLivingBomb)
         {
-            pPlayer->GetMotionMaster()->MoveDistance(pVictim, 30.0f);
-            return false;
+            pBot->SendPartyChat("Living bomb on me");
+            AnnouncedLivingBomb = true;
         }
-
-        if (pBot->GetRole() == ROLE_MELEE_DPS || pBot->GetRole() == ROLE_TANK)
+        // Check for nearby players
+        std::list<Player*> nearbyPlayers;
+        pPlayer->GetAlivePlayerListInRange(pPlayer, nearbyPlayers, 15.0f);
+        nearbyPlayers.remove(pPlayer);
+        
+        if (!nearbyPlayers.empty() && timeLeft < 5000)
         {
-            // Check if we have the Armageddon debuff
-            if (pPlayer->HasAuraType(SPELL_AURA_PERIODIC_DAMAGE))
+            if (pBot->GetRole() != ROLE_HEALER)
             {
-                float angle = pPlayer->GetAngle(pVictim);
-                float moveDist = 50.0f; // Move 50 yards away
-                float newX = pPlayer->GetPositionX() + moveDist * cos(angle + M_PI);
-                float newY = pPlayer->GetPositionY() + moveDist * sin(angle + M_PI);
-                float newZ = pPlayer->GetPositionZ();
-
-                if (pBot->SafelyMoveTo(newX, newY, newZ, angle))
+                // Run away from other players
+                float baseAngle = pPlayer->GetAngle(nearbyPlayers.front());
+                float moveDist = 20.0f;
+                bool foundSafeSpot = false;
+                
+                // Try different angles to find a safe spot
+                for (int i = 0; i < 360; i++)
                 {
-                    pBot->SendPartyChat("Running out!");
-                    return false;
+                    float testAngle = baseAngle + (i * M_PI / 4);
+                    float newX = pPlayer->GetPositionX() + moveDist * cos(testAngle + M_PI);
+                    float newY = pPlayer->GetPositionY() + moveDist * sin(testAngle + M_PI);
+                    float newZ = pPlayer->GetPositionZ();
+
+                    // Check if this position is safe from other players
+                    bool safeFromPlayers = true;
+                    for (Player* nearPlayer : nearbyPlayers)
+                    {
+                        if (nearPlayer->GetDistance2d(newX, newY) < 15.0f)
+                        {
+                            safeFromPlayers = false;
+                            break;
+                        }
+                    }
+
+                    // Check if this position is safe from the boss
+                    bool safeFromBoss = true;
+                    if (Unit* pBoss = pPlayer->GetVictim())
+                    {
+                        if (pBoss->GetDistance2d(newX, newY) < 30.0f)
+                        {
+                            safeFromBoss = false;
+                        }
+                    }
+
+                    if (safeFromPlayers && safeFromBoss)
+                    {
+                        if (pBot->SafelyMoveTo(newX, newY, newZ, testAngle))
+                        {
+                            uint32 currentTime = WorldTimer::getMSTime();
+                            if (currentTime - pBot->m_lastMoveTime > 7000)
+                                pBot->SendPartyChat("Running away from players!");
+
+                            pBot->m_lastMoveTime = currentTime;
+                            foundSafeSpot = true;
+                            return false;
+                        }
+                        else
+                        {
+                            pBot->SendPartyChat("Failed to move to safe spot");
+                        }
+                    }
+                }
+            }
+            else
+            {
+                uint32 currentTime = WorldTimer::getMSTime();
+                if (currentTime - LastInsultedTime > 5000)
+                {
+                    std::vector<std::string> insults = {
+                        "fool",
+                        "idiot",
+                        "noob",
+                        "clown",
+                        "moron",
+                        "imbecile",
+                        //--------------------------------
+                        "dipshit",
+                        "faggot",
+                        "cunt",
+                        "loser",
+                        "retard",
+                        "nig",
+                        "queer",
+                        "homo",
+                        "rabbit",
+                        "rabbi",
+                        "bear fucker",
+                        "Jackson lover"
+                        "Jerry toucher"
+                    };
+                    std::string insult = insults[urand(0, insults.size()-1)];
+                    std::string message = nearbyPlayers.size() > 1 ? 
+                        ("Get away from me you " + insult + "s!!") : 
+                        (std::string(nearbyPlayers.front()->GetName()) + ", run away from me you " + insult + "!");
+                    pBot->SendPartyChat(message.c_str());
+                    LastInsultedTime = currentTime;
+
+                    // move the other party bots away
+                    for (Player* nearPlayer : nearbyPlayers)
+                    {
+                        if (nearPlayer->AI() && nearPlayer->GetDistance(pPlayer) < 14.0f)
+                        {
+                            nearPlayer->GetMotionMaster()->MoveDistance(pPlayer, 15.0f);
+
+                            PartyBotAI* pMer = dynamic_cast<PartyBotAI*>(nearPlayer->AI());
+                            if (pMer)
+                                pMer->m_lastMoveTime = -1.0f;
+                        }
+                    }
                 }
             }
         }
+    }
+    else
+    {
+        if (pPlayer == LivingBombTarget)
+        {
+            pBot->m_lastMoveTime = 0;
+            AnnouncedLivingBomb = false;
+            LivingBombTarget = nullptr;
+        }
+    }
+
+    // Handle inferno
+    Unit* baron = pBot->SelectPartyAttackTarget();
+    if (baron && baron->HasAura(SPELL_INFERNO))
+    {
+        BaronGeddonInferno = true;
+
+        // get the fuck out if we're too close
+        if (pPlayer->GetDistance(baron) < 30.0f)
+        {
+            pPlayer->GetMotionMaster()->MoveDistance(baron, 30.0f);
+            return false;
+        }
+
+        // dont move if we're waiting for inferno to stop
+        pPlayer->SetOrientation(pPlayer->GetAngle(baron));
+        pPlayer->GetMotionMaster()->Clear();
+        pPlayer->GetMotionMaster()->MoveIdle();
+        return false;
+    }
+    else
+    {
+        BaronGeddonInferno = false;
     }
 
     return true;

--- a/src/game/PlayerBots/Encounters/MoltenCore.cpp
+++ b/src/game/PlayerBots/Encounters/MoltenCore.cpp
@@ -1,17 +1,8 @@
 #include "MoltenCore.h"
 #include "Spells/SpellAuras.h"
+#include "PlayerBots/PartyBotChat.h"
 
-#ifndef M_PI_2
-#define M_PI_2 1.57079632679489661923
-#endif
 
-#define SPELL_DISPEL_MAGIC 988
-#define SPELL_AURA_MOD_DECREASE_HEALTH 4
-#define SPELL_AURA_MOD_DECREASE_SPEED 139
-#define SPELL_LIVINGBOMB 20475
-#define SPELL_INFERNO 19695
-
-#define BARON_GEDDON 12056
 
 bool PartyBotEncounters_MC::AnnouncedLivingBomb = false;
 bool PartyBotEncounters_MC::BaronGeddonInferno = false;
@@ -21,6 +12,7 @@ uint32 PartyBotEncounters_MC::LastInsultedTime = 0;
 void PartyBotEncounters_MC::ResetEncounterVars()
 {
     m_overrideMeleePosition = false;
+    m_overrideRangedPosition = false;
     m_overrideMagicDispel = false;
     AnnouncedLivingBomb = false;
     LivingBombTarget = nullptr;
@@ -61,7 +53,7 @@ bool PartyBotEncounters_MC::HandleEncounterAI(PartyBotAI* pBot)
         (majordomoState == IN_PROGRESS) ||
         (ragnarosState == IN_PROGRESS || ragnarosState == SPECIAL);
 
-    if (!anyEncounterInProgress)
+    if (!anyEncounterInProgress && !pBot->me->IsInCombat())
         ResetEncounterVars();
     
     if (lucifronState == IN_PROGRESS)
@@ -103,6 +95,82 @@ bool PartyBotEncounters_MC::HandleEncounterAI(PartyBotAI* pBot)
     else if (ragnarosState == IN_PROGRESS || ragnarosState == SPECIAL)
     {
         return RagnarosEncounter(pBot);
+    }
+    else if (pBot->me->IsInCombat())
+    {
+        return TrashEncounter(pBot);
+    }
+
+    return true;
+}
+
+
+bool PartyBotEncounters_MC::TrashEncounter(PartyBotAI* pBot)
+{
+    Player* pPlayer = pBot->me;
+    if (!pPlayer)
+        return true;
+
+    // Stack on Lava Surgers
+    std::list<Creature*> lavaSurgers;
+    pPlayer->GetCreatureListWithEntryInGrid(lavaSurgers, LAVA_SURGER, 40.0f);
+    if (!lavaSurgers.empty())
+    {
+        Creature* surger = lavaSurgers.front();
+        if (surger && surger->IsAlive())
+        {
+            try {
+                pPlayer->GetMotionMaster()->Clear();
+                pPlayer->GetMotionMaster()->MoveChase(surger, 1.0f);
+                pPlayer->SetCasterChaseDistance(1.0f);
+                pPlayer->GetMotionMaster()->MoveDistance(surger, 1.0f);
+                m_overrideRangedPosition = true;
+            }
+            catch (std::exception& e) {
+                // fail silently
+            }
+        }
+    } else {
+        m_overrideRangedPosition = false;
+    }
+
+    // Focus Lava Spawns
+    std::list<Creature*> lavaSpawns;
+    pPlayer->GetCreatureListWithEntryInGrid(lavaSpawns, LAVA_SPAWN, 40.0f);
+    if (!lavaSpawns.empty())
+    {
+        // Check if any party members are targeting a lava spawn
+        bool assist = false;
+        if (Group* pGroup = pPlayer->GetGroup())
+        {
+            for (GroupReference* itr = pGroup->GetFirstMember(); itr != nullptr; itr = itr->next())
+            {
+                if (Player* member = itr->getSource())
+                {
+                    if (member != pPlayer && member->IsAlive())
+                    {
+                        if (Unit* memberTarget = member->GetVictim())
+                        {
+                            if (memberTarget->GetEntry() == LAVA_SPAWN)
+                            {
+                                // Set our target to the same lava spawn
+                                pPlayer->SetTargetGuid(memberTarget->GetObjectGuid());
+                                pBot->SendPartyChat(("Assisting " + std::string(member->GetName()) + " on lava spawn").c_str());
+                                assist = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!assist)
+        {
+            Creature* spawn = lavaSpawns.front();
+            pPlayer->SetTargetGuid(spawn->GetObjectGuid());
+            pBot->SendPartyChat("Focusing on lava spawn");
+        }
     }
 
     return true;
@@ -353,13 +421,43 @@ bool PartyBotEncounters_MC::GeddonEncounter(PartyBotAI* pBot)
     Player* pPlayer = pBot->me;
     if (!pPlayer)
         return true;
+    
+    if (!pPlayer->IsAlive())
+        return true;
+
+    // Healers need to prioritize dispelling Ignite Mana
+    uint8 pClass = pPlayer->GetClass();
+    if (pClass == CLASS_PRIEST || pClass == CLASS_PALADIN)
+    {
+        if (pPlayer->HasAura(BARON_IGNITEMANA))
+        {
+            PartyBotEncounters::DispelMagic(pBot, pPlayer);
+        }
+        else if (Group* group = pPlayer->GetGroup())
+        {
+            for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
+            {
+                if (Player* member = itr->getSource())
+                {
+                    if (member->IsAlive() && member->HasAura(BARON_IGNITEMANA))
+                    {
+                        if (member->GetPowerType() == POWER_MANA)
+                            PartyBotEncounters::DispelMagic(pBot, member);
+                    }
+                }
+            }
+        }
+    }
 
     if (pPlayer->IsMoving() && !BaronGeddonInferno)
         return false;
+
+    Unit* baron = pBot->SelectAttackTarget(pBot->GetPartyLeader());
     
-    if (pPlayer->HasAura(SPELL_LIVINGBOMB))
+    // Handle living bomb
+    if (pPlayer->HasAura(BARON_LIVINGBOMB))
     {
-        uint32 timeLeft = pPlayer->GetSpellAuraHolder(SPELL_LIVINGBOMB)->GetAuraDuration();
+        uint32 timeLeft = pPlayer->GetSpellAuraHolder(BARON_LIVINGBOMB)->GetAuraDuration();
         
         LivingBombTarget = pPlayer;
 
@@ -379,15 +477,16 @@ bool PartyBotEncounters_MC::GeddonEncounter(PartyBotAI* pBot)
             {
                 // Run away from other players
                 float baseAngle = pPlayer->GetAngle(nearbyPlayers.front());
-                float moveDist = 20.0f;
-                bool foundSafeSpot = false;
+                float moveDist = 15.0f;
                 
                 // Try different angles to find a safe spot
-                for (int i = 0; i < 360; i++)
-                {
-                    float testAngle = baseAngle + (i * M_PI / 4);
-                    float newX = pPlayer->GetPositionX() + moveDist * cos(testAngle + M_PI);
-                    float newY = pPlayer->GetPositionY() + moveDist * sin(testAngle + M_PI);
+                bool foundSafeSpot = false;
+                float currentDist = moveDist;
+                int angleIndex = 0;
+                do {
+                    float testAngle = baseAngle + (angleIndex * M_PI);
+                    float newX = pPlayer->GetPositionX() + currentDist * cos(testAngle + M_PI);
+                    float newY = pPlayer->GetPositionY() + currentDist * sin(testAngle + M_PI);
                     float newZ = pPlayer->GetPositionZ();
 
                     // Check if this position is safe from other players
@@ -403,12 +502,10 @@ bool PartyBotEncounters_MC::GeddonEncounter(PartyBotAI* pBot)
 
                     // Check if this position is safe from the boss
                     bool safeFromBoss = true;
-                    if (Unit* pBoss = pPlayer->GetVictim())
+                    if (baron)
                     {
-                        if (pBoss->GetDistance2d(newX, newY) < 30.0f)
-                        {
+                        if (baron->GetDistance2d(newX, newY) < 30.0f)
                             safeFromBoss = false;
-                        }
                     }
 
                     if (safeFromPlayers && safeFromBoss)
@@ -417,16 +514,32 @@ bool PartyBotEncounters_MC::GeddonEncounter(PartyBotAI* pBot)
                         {
                             uint32 currentTime = WorldTimer::getMSTime();
                             if (currentTime - pBot->m_lastMoveTime > 7000)
+                            {
                                 pBot->SendPartyChat("Running away from players!");
+                                pBot->m_lastMoveTime = currentTime;
+                                foundSafeSpot = true;
+                                return false;
+                            }
+                        }
+                    }
+                    angleIndex++;
+                    if (angleIndex >= 359) // After trying all angles at current distance
+                    {
+                        angleIndex = 0;
+                        currentDist += 5.0f; // Increase distance by 5 yards each iteration
+                    }
+                } while (!foundSafeSpot && currentDist <= 50.0f);
 
-                            pBot->m_lastMoveTime = currentTime;
-                            foundSafeSpot = true;
-                            return false;
-                        }
-                        else
-                        {
-                            pBot->SendPartyChat("Failed to move to safe spot");
-                        }
+                if (!foundSafeSpot)
+                {
+                    uint32 currentTime = WorldTimer::getMSTime();
+                    if (currentTime - pBot->m_lastMoveTime > 4000)
+                    {
+                        pBot->SendPartyChat("brb squatting on a breadstick");
+                        Player* pDaddy = nearbyPlayers.front();
+                        pPlayer->GetMotionMaster()->MoveDistance(pDaddy, 15.0f);
+                        pBot->m_lastMoveTime = currentTime;
+                        return false;
                     }
                 }
             }
@@ -435,29 +548,7 @@ bool PartyBotEncounters_MC::GeddonEncounter(PartyBotAI* pBot)
                 uint32 currentTime = WorldTimer::getMSTime();
                 if (currentTime - LastInsultedTime > 5000)
                 {
-                    std::vector<std::string> insults = {
-                        "fool",
-                        "idiot",
-                        "noob",
-                        "clown",
-                        "moron",
-                        "imbecile",
-                        //--------------------------------
-                        "dipshit",
-                        "faggot",
-                        "cunt",
-                        "loser",
-                        "retard",
-                        "nig",
-                        "queer",
-                        "homo",
-                        "rabbit",
-                        "rabbi",
-                        "bear fucker",
-                        "Jackson lover"
-                        "Jerry toucher"
-                    };
-                    std::string insult = insults[urand(0, insults.size()-1)];
+                    std::string insult = PartyBotChat::GetInsult();
                     std::string message = nearbyPlayers.size() > 1 ? 
                         ("Get away from me you " + insult + "s!!") : 
                         (std::string(nearbyPlayers.front()->GetName()) + ", run away from me you " + insult + "!");
@@ -469,11 +560,14 @@ bool PartyBotEncounters_MC::GeddonEncounter(PartyBotAI* pBot)
                     {
                         if (nearPlayer->AI() && nearPlayer->GetDistance(pPlayer) < 14.0f)
                         {
+                            PartyBotAI* paiNear = dynamic_cast<PartyBotAI*>(nearPlayer->AI());
+                            if (paiNear)
+                            {
+                                std::string response = PartyBotChat::GetInsultResponse();
+                                paiNear->SendPartyChat(response.c_str(), urand(1000, 3000));
+                                paiNear->m_lastMoveTime = currentTime;
+                            }
                             nearPlayer->GetMotionMaster()->MoveDistance(pPlayer, 15.0f);
-
-                            PartyBotAI* pMer = dynamic_cast<PartyBotAI*>(nearPlayer->AI());
-                            if (pMer)
-                                pMer->m_lastMoveTime = -1.0f;
                         }
                     }
                 }
@@ -484,15 +578,14 @@ bool PartyBotEncounters_MC::GeddonEncounter(PartyBotAI* pBot)
     {
         if (pPlayer == LivingBombTarget)
         {
-            pBot->m_lastMoveTime = 0;
             AnnouncedLivingBomb = false;
             LivingBombTarget = nullptr;
         }
     }
 
+
     // Handle inferno
-    Unit* baron = pBot->SelectPartyAttackTarget();
-    if (baron && baron->HasAura(SPELL_INFERNO))
+    if (baron && baron->HasAura(BARON_INFERNO))
     {
         BaronGeddonInferno = true;
 
@@ -504,14 +597,56 @@ bool PartyBotEncounters_MC::GeddonEncounter(PartyBotAI* pBot)
         }
 
         // dont move if we're waiting for inferno to stop
-        pPlayer->SetOrientation(pPlayer->GetAngle(baron));
-        pPlayer->GetMotionMaster()->Clear();
-        pPlayer->GetMotionMaster()->MoveIdle();
-        return false;
+        if (LivingBombTarget != pPlayer)
+        {
+            pPlayer->GetMotionMaster()->Clear();
+            pPlayer->GetMotionMaster()->MoveIdle();
+            return false;
+        }
+        else
+        {
+            // Move away from other players since we have living bomb
+            std::list<Player*> nearbyPlayers;
+            pPlayer->GetAlivePlayerListInRange(pPlayer, nearbyPlayers, 15.0f);
+            nearbyPlayers.remove(pPlayer);
+
+            if (!nearbyPlayers.empty())
+            {
+                pBot->SendPartyChat("Living bomb on me, running away!");
+                float baseAngle = pPlayer->GetAngle(nearbyPlayers.front());
+                float moveDist = 15.0f;
+                float newX = pPlayer->GetPositionX() + moveDist * cos(baseAngle);
+                float newY = pPlayer->GetPositionY() + moveDist * sin(baseAngle);
+                float newZ = pPlayer->GetPositionZ();
+                pPlayer->GetMotionMaster()->Clear();
+                pBot->SafelyMoveTo(newX, newY, newZ, pPlayer->GetAngle(baron));
+                return false;
+            }
+        }
     }
     else
     {
         BaronGeddonInferno = false;
+
+        if(baron)
+        {
+            // run out if we're too close to the boss
+            if ((pBot->GetRole() == ROLE_HEALER || pBot->GetRole() == ROLE_RANGE_DPS) &&
+                !pBot->IsStaying())
+            {
+                if (pPlayer->GetDistance(baron) < 25.0f && 
+                !pPlayer->IsMoving() && !pPlayer->IsNonMeleeSpellCasted())
+                {
+                    pPlayer->GetMotionMaster()->MoveDistance(baron, 30.0f);
+                    return false;
+                }
+
+                // Ensure we're facing the boss
+                pPlayer->SetCasterChaseDistance(32.0f);
+                pPlayer->GetMotionMaster()->MoveChase(baron, 30.0f, frand(0, M_PI / 2));
+                pBot->AttackStart(baron);                
+            }
+        }
     }
 
     return true;

--- a/src/game/PlayerBots/Encounters/MoltenCore.cpp
+++ b/src/game/PlayerBots/Encounters/MoltenCore.cpp
@@ -1,10 +1,3 @@
-#include "SharedDefines.h"
-#include "MotionMaster.h"
-#include "Unit.h"
-#include "Player.h"
-#include "Spell.h"
-#include "PartyBotAI.h"
-#include "ScriptedInstance.h"
 #include "MoltenCore.h"
 
 #ifndef M_PI_2

--- a/src/game/PlayerBots/Encounters/MoltenCore.h
+++ b/src/game/PlayerBots/Encounters/MoltenCore.h
@@ -14,6 +14,12 @@ enum EncounterIds
     TYPE_MAJORDOMO = 8,
     TYPE_RAGNAROS  = 9
 };
+
+enum Bolos
+{
+    LAVA_SURGER = 12101,
+    LAVA_SPAWN = 12265    
+};
     
 class PartyBotEncounters_MC : public PartyBotEncounters
 {
@@ -30,4 +36,11 @@ public:
     static bool GolemaggEncounter(PartyBotAI* pBot);
     static bool MajordomoEncounter(PartyBotAI* pBot);
     static bool RagnarosEncounter(PartyBotAI* pBot);
+
+    static void ResetEncounterVars();
+
+    static bool AnnouncedLivingBomb;
+    static Player* LivingBombTarget;
+    static bool BaronGeddonInferno;
+    static uint32 LastInsultedTime;
 };

--- a/src/game/PlayerBots/Encounters/MoltenCore.h
+++ b/src/game/PlayerBots/Encounters/MoltenCore.h
@@ -1,6 +1,20 @@
 #include "PartyBotAI.h"
 #include "PartyBotEncounters.h"
 
+// Trash Priorities
+#define LAVA_SURGER 12101
+#define LAVA_SPAWN 12265
+
+// Baron Geddon
+#define BARON_LIVINGBOMB 20475
+#define BARON_INFERNO 19695
+#define BARON_IGNITEMANA 19659
+#define BARON_ARMAGEDDON 20478
+
+// Gehennas
+#define GEHENNAS_CURSE 19716
+#define GEHENNAS_RAIN_OF_FIRE 19717
+
 enum EncounterIds
 {
     TYPE_SULFURON  = 0,
@@ -13,12 +27,6 @@ enum EncounterIds
     TYPE_LUCIFRON  = 7,
     TYPE_MAJORDOMO = 8,
     TYPE_RAGNAROS  = 9
-};
-
-enum Bolos
-{
-    LAVA_SURGER = 12101,
-    LAVA_SPAWN = 12265    
 };
     
 class PartyBotEncounters_MC : public PartyBotEncounters
@@ -36,11 +44,12 @@ public:
     static bool GolemaggEncounter(PartyBotAI* pBot);
     static bool MajordomoEncounter(PartyBotAI* pBot);
     static bool RagnarosEncounter(PartyBotAI* pBot);
+    static bool TrashEncounter(PartyBotAI* pBot);
 
     static void ResetEncounterVars();
 
     static bool AnnouncedLivingBomb;
-    static Player* LivingBombTarget;
     static bool BaronGeddonInferno;
     static uint32 LastInsultedTime;
+    static Player* LivingBombTarget;
 };

--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -348,7 +348,7 @@ bool PartyBotAI::AttackStart(Unit* pVictim)
     if (GetRole() == ROLE_HEALER)
     {
         if (!m_isStaying) {
-            me->SetCasterChaseDistance(25.0f);
+            me->SetCasterChaseDistance(30.0f);
             me->GetMotionMaster()->MoveChase(pVictim, 1.0f, 0.0f);
         } else {
             me->GetMotionMaster()->Clear(false, true);
@@ -359,10 +359,8 @@ bool PartyBotAI::AttackStart(Unit* pVictim)
 
     if (me->Attack(pVictim, true))
     {
-        if (GetRole() == ROLE_RANGE_DPS &&
-            me->GetPowerPercent(POWER_MANA) > 10.0f &&
-            me->GetCombatDistance(pVictim) > 8.0f)
-            me->SetCasterChaseDistance(25.0f);
+        if (GetRole() == ROLE_RANGE_DPS)
+            me->SetCasterChaseDistance(30.0f);
         else if (me->HasDistanceCasterMovement())
             me->SetCasterChaseDistance(0.0f);
 
@@ -374,7 +372,7 @@ bool PartyBotAI::AttackStart(Unit* pVictim)
             }
             else
             {
-                me->SetCasterChaseDistance(GetRole() == ROLE_TANK ? 0.0f : 25.0f);
+                me->SetCasterChaseDistance(GetRole() == ROLE_TANK ? 0.0f : 30.0f);
                 me->GetMotionMaster()->MoveChase(pVictim, 1.0f, 0.0f);
             }
         }
@@ -1011,7 +1009,7 @@ void PartyBotAI::UpdateAI(uint32 const diff)
                     case IDLE_MOTION_TYPE:
                     case FOLLOW_MOTION_TYPE:
                         bool isMeleeDpsOrTank = (GetRole() == ROLE_MELEE_DPS || GetRole() == ROLE_TANK);
-                        float chaseDistance = isMeleeDpsOrTank ? 0.0f : 25.0f;
+                        float chaseDistance = isMeleeDpsOrTank ? 0.0f : 30.0f;
                         if (!isMeleeDpsOrTank)
                             me->SetCasterChaseDistance(chaseDistance);
 
@@ -1639,10 +1637,10 @@ void PartyBotAI::UpdateInCombatAI_Hunter()
     if (Unit* pVictim = me->GetVictim())
     {
         if (me->GetMotionMaster()->GetCurrentMovementGeneratorType() == IDLE_MOTION_TYPE &&
-            me->GetDistance(pVictim) > 30.0f &&
+            me->GetDistance(pVictim) > 35.0f &&
             !m_isStaying)
         {
-            me->GetMotionMaster()->MoveChase(pVictim, 25.0f);
+            me->GetMotionMaster()->MoveChase(pVictim, 30.0f);
         }
 
         if (m_spells.hunter.pVolley &&
@@ -1907,9 +1905,9 @@ void PartyBotAI::UpdateInCombatAI_Mage()
         }
 
         if (me->GetMotionMaster()->GetCurrentMovementGeneratorType() == IDLE_MOTION_TYPE
-            && me->GetDistance(pVictim) > 30.0f)
+            && me->GetDistance(pVictim) > 35.0f)
         {
-            me->GetMotionMaster()->MoveChase(pVictim, 25.0f);
+            me->GetMotionMaster()->MoveChase(pVictim, 30.0f);
         }
         else if (GetAttackersInRangeCount(10.0f))
         {
@@ -1948,7 +1946,7 @@ void PartyBotAI::UpdateInCombatAI_Mage()
 
                     if (RunAwayFromTarget(pVictim))
                     {
-                        me->SetCasterChaseDistance(25.0f);
+                        me->SetCasterChaseDistance(30.0f);
                         return;
                     }
                 }
@@ -2395,9 +2393,9 @@ void PartyBotAI::UpdateInCombatAI_Priest()
         }
 
         if (me->GetMotionMaster()->GetCurrentMovementGeneratorType() == IDLE_MOTION_TYPE
-            && me->GetDistance(pVictim) > 30.0f)
+            && me->GetDistance(pVictim) > 35.0f)
         {
-            me->GetMotionMaster()->MoveChase(pVictim, 25.0f);
+            me->GetMotionMaster()->MoveChase(pVictim, 30.0f);
         }
 
         if (me->GetShapeshiftForm() == FORM_NONE)
@@ -2598,9 +2596,9 @@ void PartyBotAI::UpdateInCombatAI_Warlock()
         }
 
         if (me->GetMotionMaster()->GetCurrentMovementGeneratorType() == IDLE_MOTION_TYPE
-            && me->GetDistance(pVictim) > 30.0f)
+            && me->GetDistance(pVictim) > 35.0f)
         {
-            me->GetMotionMaster()->MoveChase(pVictim, 25.0f);
+            me->GetMotionMaster()->MoveChase(pVictim, 30.0f);
         }
 
         if (m_spells.warlock.pHowlofTerror &&
@@ -3597,11 +3595,11 @@ void PartyBotAI::UpdateInCombatAI_Druid()
         case FORM_MOONKIN:
         {
             if (me->GetMotionMaster()->GetCurrentMovementGeneratorType() == IDLE_MOTION_TYPE &&
-                me->GetDistance(pVictim) > 30.0f)
+                me->GetDistance(pVictim) > 35.0f)
             {
                 if (!m_isStaying)
                 {
-                    me->GetMotionMaster()->MoveChase(pVictim, 25.0f);
+                    me->GetMotionMaster()->MoveChase(pVictim, 30.0f);
                 }
             }
             else if (pVictim->CanReachWithMeleeAutoAttack(me) &&
@@ -3615,7 +3613,7 @@ void PartyBotAI::UpdateInCombatAI_Druid()
                     if (DoCastSpell(pVictim, m_spells.druid.pEntanglingRoots) == SPELL_CAST_OK)
                         return;
                 }
-                me->SetCasterChaseDistance(25.0f);
+                me->SetCasterChaseDistance(30.0f);
                 if (RunAwayFromTarget(pVictim))
                     return;
             }

--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -3896,33 +3896,6 @@ bool PartyBotAI::SafelyMoveTo(float x, float y, float z, float angle)
     return true;
 }
 
-std::string PartyBotAI::GetHealerTankAnnouncementText(const char* pName)
-{
-    char message[128];
-    uint8 pClass = me->GetClass();
-    
-    switch (pClass)
-    {
-        case CLASS_PRIEST:
-            snprintf(message, sizeof(message), "By the grace of the Light, I stand ready. %s is chosen as the vanguard—I shall be their balm.", pName);
-            break;
-        case CLASS_DRUID:
-            snprintf(message, sizeof(message), "By Nature's blessing, I shall keep %s whole through whatever trials await.", pName);
-            break;
-        case CLASS_PALADIN:
-            snprintf(message, sizeof(message), "The Light guide us—%s stands as my shield. I shall mend the wounds of battle.", pName);
-            break;
-        case CLASS_SHAMAN:
-            snprintf(message, sizeof(message), "The elements grant me power to preserve %s's strength in battle.", pName);
-            break;
-        default:
-            snprintf(message, sizeof(message), "I will focus my healing on %s, our protector. (Class: %d)", pName, pClass);
-            break;
-    }
-    return message;
-}
-
-
 Player* PartyBotAI::GetTankPlayer()
 {
     Group* pGroup = me->GetGroup();
@@ -3948,12 +3921,9 @@ Player* PartyBotAI::GetTankPlayer()
         if (pMember->AI() && dynamic_cast<PartyBotAI*>(pMember->AI()) && 
             dynamic_cast<PartyBotAI*>(pMember->AI())->GetRole() == ROLE_TANK)
         {
-            if (GetRole() == ROLE_HEALER && !m_hasAnnouncedTank)
-            {
-                std::string message = GetHealerTankAnnouncementText(pMember->GetName());
-                SendPartyChat(message.c_str());
-                m_hasAnnouncedTank = true;
-            }
+            if (GetRole() == ROLE_HEALER && !PartyChat->HasHealerAnnouncedTank)
+                PartyChat->HealerAnnounceTank(pMember->GetName(), me);
+            
             return pMember;
         }
         
@@ -3968,12 +3938,9 @@ Player* PartyBotAI::GetTankPlayer()
     // If only one tank-capable class exists, they must be the tank
     if (tankClassCount == 1 && firstTankClass)
     {
-        if (GetRole() == ROLE_HEALER && !m_hasAnnouncedTank)
-        {
-            std::string message = GetHealerTankAnnouncementText(firstTankClass->GetName());
-            SendPartyChat(message.c_str());
-            m_hasAnnouncedTank = true;
-        }
+        if (GetRole() == ROLE_HEALER && !PartyChat->HasHealerAnnouncedTank)
+            PartyChat->HealerAnnounceTank(firstTankClass->GetName(), me);
+        
         return firstTankClass;
     }
 
@@ -4007,23 +3974,17 @@ Player* PartyBotAI::GetTankPlayer()
                 continue;
         }
 
-        if (GetRole() == ROLE_HEALER && !m_hasAnnouncedTank)
-        {
-            std::string message = GetHealerTankAnnouncementText(pMember->GetName());
-            SendPartyChat(message.c_str());
-            m_hasAnnouncedTank = true;
-        }
+        if (GetRole() == ROLE_HEALER && !PartyChat->HasHealerAnnouncedTank)
+            PartyChat->HealerAnnounceTank(pMember->GetName(), me);
+        
         return pMember;
     }
 
     // If no tank is found, return the first party member
     Player* firstMember = pGroup->GetFirstMember()->getSource();
-    if (GetRole() == ROLE_HEALER && !m_hasAnnouncedTank)
-    {
-        std::string message = GetHealerTankAnnouncementText(firstMember->GetName());
-        SendPartyChat(message.c_str());
-        m_hasAnnouncedTank = true;
-    }
+    if (GetRole() == ROLE_HEALER && !PartyChat->HasHealerAnnouncedTank)
+        PartyChat->HealerAnnounceTank(firstMember->GetName(), me);
+    
     return firstMember;
 }
 
@@ -4064,15 +4025,4 @@ bool PartyBotAI::HasEnemiesInRadius(float x, float y, float z, float radius) con
         }
     }
     return false;
-}
-
-void PartyBotAI::SendPartyChat(const char* message) const
-{
-    if (!me || !me->GetGroup())
-        return;
-
-    WorldPacket* data = new WorldPacket();
-    ChatHandler::BuildChatPacket(*data, CHAT_MSG_PARTY, message, LANG_UNIVERSAL, CHAT_TAG_NONE, me->GetObjectGuid(), me->GetName());
-    me->GetGroup()->BroadcastPacket(data, false);
-    delete data;
 }

--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -356,25 +356,38 @@ bool PartyBotAI::AttackStart(Unit* pVictim)
         }
         return true;
     }
+    else if (GetRole() == ROLE_RANGE_DPS)
+    {
+        if (!m_isStaying)
+        {
+            if (me->Attack(pVictim, false))
+            {
+                me->GetMotionMaster()->Clear(false, true);
+                me->SetCasterChaseDistance(30.0f);
+                me->GetMotionMaster()->MoveChase(pVictim, 30.0f, frand(0, 2 * M_PI));
+                return true;
+            }
+        }
+        else
+        {
+            me->GetMotionMaster()->Clear(false, true);
+            me->GetMotionMaster()->MoveIdle();
+        }
+        return true;
+    }
 
     if (me->Attack(pVictim, true))
     {
-        if (GetRole() == ROLE_RANGE_DPS)
-            me->SetCasterChaseDistance(30.0f);
-        else if (me->HasDistanceCasterMovement())
-            me->SetCasterChaseDistance(0.0f);
+        me->SetCasterChaseDistance(0.0f);
 
         if (!m_isStaying)
         {
             if (GetRole() == ROLE_MELEE_DPS)
-            {
                 RepositionMeleeDps();
-            }
-            else
-            {
-                me->SetCasterChaseDistance(GetRole() == ROLE_TANK ? 0.0f : 30.0f);
-                me->GetMotionMaster()->MoveChase(pVictim, 1.0f, 0.0f);
-            }
+
+        } else {
+            me->GetMotionMaster()->Clear();
+            me->GetMotionMaster()->MoveIdle();
         }
         
         return true;
@@ -402,7 +415,7 @@ Unit* PartyBotAI::SelectAttackTarget(Player* pLeader) const
     else
     {
         // Stick to marked target in combat.
-        if (me->IsInCombat() || pLeader->GetVictim())
+        if (me->IsInCombat())
         {        
             for (auto markId : m_marksToFocus)
             {
@@ -1773,6 +1786,7 @@ void PartyBotAI::UpdateInCombatAI_Hunter()
         if (!me->HasUnitState(UNIT_STATE_ROOT) &&
             (me->GetCombatDistance(pVictim) < 8.0f) &&
             (GetRole() != ROLE_MELEE_DPS) &&
+            !PartyBotEncounters::OverrideRangedPosition() &&
              me->GetMotionMaster()->GetCurrentMovementGeneratorType() != DISTANCING_MOTION_TYPE)
         {
             if (!me->IsStopped())

--- a/src/game/PlayerBots/PartyBotAI.h
+++ b/src/game/PlayerBots/PartyBotAI.h
@@ -20,6 +20,7 @@
 #include "CombatBotBaseAI.h"
 #include "Group.h"
 #include "ObjectAccessor.h"
+#include "PartyBotChat.h"
 #include "PartyBotEncounters.h"
 
 #define PB_UPDATE_INTERVAL 1000
@@ -42,7 +43,6 @@ public:
         m_isStaying = false;
         m_isBuffing = false;
         m_leaderReleased = false;
-        m_hasAnnouncedTank = false;
         m_lastMoveTime = 0;
     }
     PartyBotAI(Player* pLeader, uint32 mapId, uint32 instanceId, float x, float y, float z, float o)
@@ -54,7 +54,6 @@ public:
         m_isStaying = false;
         m_isBuffing = false;
         m_leaderReleased = false;
-        m_hasAnnouncedTank = false;
         m_lastMoveTime = 0;
     }
 
@@ -115,9 +114,8 @@ public:
     bool SafelyMoveTo(float x, float y, float z, float angle = 0.0f);
     bool ShouldReviveWithOwner();
     bool HasEnemiesInRadius(float x, float y, float z, float radius) const;
-    void SendPartyChat(const char* message) const;
-    std::string GetHealerTankAnnouncementText(const char* pName);
-
+    
+    PartyBotChat* PartyChat = PartyBotChat::GetInstance();
     std::vector<RaidTargetIcon> m_marksToCC;
     std::vector<RaidTargetIcon> m_marksToFocus;
     ShortTimeTracker m_updateTimer;
@@ -128,6 +126,7 @@ public:
     uint8 m_level = 0;
     uint32 m_mapId = 0;
     uint32 m_instanceId = 0;
+    uint32 m_lastMoveTime = 0;
     float m_x = 0.0f;
     float m_y = 0.0f;
     float m_z = 0.0f;
@@ -136,8 +135,14 @@ public:
     bool m_isStaying = false;
     bool m_leaderReleased = false;
     bool m_isBuffing = false;
-    bool m_hasAnnouncedTank = false;
-    uint32 m_lastMoveTime;  // Cooldown for Magmadar encounter movement
+
+    void SendPartyChat(const char* msg)
+    {
+        if (!me || !me->GetGroup())
+            return;
+
+        PartyBotChat::GetInstance()->SendPartyChat(msg, me);
+    }
 };
 
 #endif

--- a/src/game/PlayerBots/PartyBotAI.h
+++ b/src/game/PlayerBots/PartyBotAI.h
@@ -136,12 +136,12 @@ public:
     bool m_leaderReleased = false;
     bool m_isBuffing = false;
 
-    void SendPartyChat(const char* msg)
+    void SendPartyChat(const char* msg, uint32 delay = 0)
     {
         if (!me || !me->GetGroup())
             return;
 
-        PartyBotChat::GetInstance()->SendPartyChat(msg, me);
+        PartyBotChat::GetInstance()->SendPartyChat(msg, me, delay);
     }
 };
 

--- a/src/game/PlayerBots/PartyBotChat.cpp
+++ b/src/game/PlayerBots/PartyBotChat.cpp
@@ -3,7 +3,8 @@
 
 PartyBotChat* PartyBotChat::instance = nullptr;
 
-const std::set<std::string> PartyBotChat::greetings = {
+
+const std::vector<std::string> PartyBotChat::greetings = {
     "hey",
     "hello",
     "hi",
@@ -15,6 +16,43 @@ const std::set<std::string> PartyBotChat::greetings = {
     "whats good",
 };
 
+
+const std::vector<std::string> PartyBotChat::insults = {
+    "fool",
+    "idiot",
+    "noob",
+    "clown",
+    "moron",
+    "imbecile",
+    "dipshit",
+    "faggot",
+    "cunt",
+    "loser",
+    "retard",
+    "nig",
+    "queer",
+    "homo",
+    "rabbit",
+    "rabbi",
+    "bear fucker",
+    "Jackson lover",
+    "Jerry toucher"
+};
+
+
+const std::vector<std::string> PartyBotChat::insultResponses = {
+    "I'm not a fan of your kind",
+    "Fuck you",
+    "Go fuck yourself",
+    "I'm not in the mood for your shit",
+    "Damn chill out",
+    "Tu madre",
+    "Rofl",
+    "Lmao",
+    "Ok",
+    "Whatever",
+    "I'm busy"
+};
 
 PartyBotChat* PartyBotChat::GetInstance()
 {
@@ -59,6 +97,18 @@ std::string PartyBotChat::GetHealerTankAnnouncementText(const char* pName, Playe
 }
 
 
+std::string PartyBotChat::GetInsult()
+{
+    return insults[urand(0, insults.size()-1)];
+}
+
+
+std::string PartyBotChat::GetInsultResponse()
+{
+    return insultResponses[urand(0, insultResponses.size()-1)];
+}
+
+
 void PartyBotChat::SendPartyChat(const char* message, Player* player) const
 {
     if (!player || !player->GetGroup())
@@ -68,6 +118,36 @@ void PartyBotChat::SendPartyChat(const char* message, Player* player) const
     ChatHandler::BuildChatPacket(*data, CHAT_MSG_PARTY, message, LANG_UNIVERSAL, CHAT_TAG_NONE, player->GetObjectGuid(), player->GetName());
     player->GetGroup()->BroadcastPacket(data, false);
     delete data;
+}
+
+void PartyBotChat::SendPartyChat(const char* message, Player* player, float delay) const
+{
+    if (!player || !player->GetGroup())
+        return;
+
+    // Schedule this task to execute after delay (milliseconds)
+    if (delay > 0)
+    {
+        auto sendPartyMessage = [message = std::string(message), playerGuid = player->GetObjectGuid()]() {
+            if (Player* playerPtr = sObjectMgr.GetPlayer(playerGuid))
+            {
+                if (Group* group = playerPtr->GetGroup())
+                {
+                    WorldPacket* data = new WorldPacket();
+                    ChatHandler::BuildChatPacket(*data, CHAT_MSG_PARTY, message.c_str(), LANG_UNIVERSAL, CHAT_TAG_NONE, playerPtr->GetObjectGuid(), playerPtr->GetName());
+                    group->BroadcastPacket(data, false);
+                    delete data;
+                }
+            }
+        };
+        GetSWorld().GetMessager().AddMessage([sendPartyMessage, delay](World* world) {
+            world->AddAsyncTask(sendPartyMessage);
+        });
+    }
+    else
+    {
+        SendPartyChat(message, player);
+    }
 }
 
 
@@ -120,7 +200,7 @@ void PartyBotChat::ProcessPartyMessage(ObjectGuid const& senderGuid, std::string
     std::transform(msg.begin(), msg.end(), msg.begin(), ::tolower);
 
     // Greetings
-    if (greetings.find(msg) != greetings.end())
+    if (std::find(greetings.begin(), greetings.end(), msg) != greetings.end())
     {
         if (Group* group = sender->GetGroup())
         {
@@ -135,6 +215,35 @@ void PartyBotChat::ProcessPartyMessage(ObjectGuid const& senderGuid, std::string
                     {
                         std::string greeting = *std::next(greetings.begin(), rand() % greetings.size());
                         std::string response = (char)toupper(greeting[0]) + greeting.substr(1) + " " + playerName + "!";
+                        SendPartyChat(response.c_str(), pMember, urand(1000, 4000));
+                    }
+                }
+            }
+        }
+    }
+
+
+    // My name
+    // Check if message contains bot names
+    if (Group* group = sender->GetGroup())
+    {
+        for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
+        {
+            if (Player* pMember = itr->getSource())
+            {
+                if (pMember->GetGUIDLow() == playerGuid)
+                    continue;
+
+                if (pMember->AI())
+                {
+                    std::string mName = pMember->GetName();
+                    uint8 mClass = pMember->GetClass();
+                    std::string mNameLower = mName;
+                    std::transform(mNameLower.begin(), mNameLower.end(), mNameLower.begin(), ::tolower);
+
+                    if (msg.find(mNameLower) != std::string::npos)
+                    {
+                        std::string response = GetInsultResponse() + " " + playerName + "!";
                         SendPartyChat(response.c_str(), pMember);
                     }
                 }

--- a/src/game/PlayerBots/PartyBotChat.cpp
+++ b/src/game/PlayerBots/PartyBotChat.cpp
@@ -1,0 +1,144 @@
+#include "PartyBotAI.h"
+#include "PartyBotChat.h"
+
+PartyBotChat* PartyBotChat::instance = nullptr;
+
+const std::set<std::string> PartyBotChat::greetings = {
+    "hey",
+    "hello",
+    "hi",
+    "greetings",
+    "salutations",
+    "yo",
+    "sup",
+    "what's good",
+    "whats good",
+};
+
+
+PartyBotChat* PartyBotChat::GetInstance()
+{
+    if (!instance)
+        instance = new PartyBotChat();
+    
+    return instance;
+}
+
+
+void PartyBotChat::HealerAnnounceTank(const char* pName, Player* player)
+{
+    std::string message = GetHealerTankAnnouncementText(pName, player);
+    SendPartyChat(message.c_str(), player);
+    HasHealerAnnouncedTank = true;
+}
+
+std::string PartyBotChat::GetHealerTankAnnouncementText(const char* pName, Player* player)
+{
+    char message[128];
+    uint8 pClass = player->GetClass();
+    
+    switch (pClass)
+    {
+        case CLASS_PRIEST:
+            snprintf(message, sizeof(message), "By the grace of the Light, I stand ready. %s is chosen as the vanguard—I shall be their balm.", pName);
+            break;
+        case CLASS_DRUID:
+            snprintf(message, sizeof(message), "By Nature's blessing, I shall keep %s whole through whatever trials await.", pName);
+            break;
+        case CLASS_PALADIN:
+            snprintf(message, sizeof(message), "The Light guide us—%s stands as my shield. I shall mend the wounds of battle.", pName);
+            break;
+        case CLASS_SHAMAN:
+            snprintf(message, sizeof(message), "The elements grant me power to preserve %s's strength in battle.", pName);
+            break;
+        default:
+            snprintf(message, sizeof(message), "I will focus my healing on %s, our protector. (Class: %d)", pName, pClass);
+            break;
+    }
+    return message;
+}
+
+
+void PartyBotChat::SendPartyChat(const char* message, Player* player) const
+{
+    if (!player || !player->GetGroup())
+        return;
+
+    WorldPacket* data = new WorldPacket();
+    ChatHandler::BuildChatPacket(*data, CHAT_MSG_PARTY, message, LANG_UNIVERSAL, CHAT_TAG_NONE, player->GetObjectGuid(), player->GetName());
+    player->GetGroup()->BroadcastPacket(data, false);
+    delete data;
+}
+
+
+void PartyBotChat::OnPacketReceived(WorldPacket const* packet)
+{
+    uint8 msgtype = 0;
+    uint32 lang = 0;
+    ObjectGuid senderGuid;
+    ObjectGuid targetGuid;
+    uint32 msgLen = 0;
+    std::string message;
+
+    try {
+        WorldPacket& buffer = const_cast<WorldPacket&>(*packet);
+        buffer >> msgtype;
+        buffer >> lang;
+        buffer >> senderGuid;
+        buffer >> targetGuid;
+        buffer >> msgLen;
+        
+        if (msgLen > 0 && msgLen <= 255)
+            buffer >> message;
+
+        ProcessPartyMessage(senderGuid, message);
+    }
+    catch (ByteBufferException const& e) {
+        return;
+    }
+}
+
+void PartyBotChat::ProcessPartyMessage(ObjectGuid const& senderGuid, std::string const& message)
+{    
+    Player* sender = ObjectAccessor::FindPlayer(senderGuid);
+    if (!sender)
+        return;
+
+    // Extract player name and guid
+    std::string senderInfo = senderGuid.GetString();
+    size_t nameStart = senderInfo.find("Player ") + 7;
+    size_t nameEnd = senderInfo.find(" (Guid");
+    std::string playerName = senderInfo.substr(nameStart, nameEnd - nameStart);
+    size_t guidStart = senderInfo.find("Guid: ") + 6; 
+    size_t guidEnd = senderInfo.find(")");
+    uint32 playerGuid = std::stoul(senderInfo.substr(guidStart, guidEnd - guidStart));
+
+    
+
+    // Process the message
+    std::string msg = message;
+    std::transform(msg.begin(), msg.end(), msg.begin(), ::tolower);
+
+    // Greetings
+    if (greetings.find(msg) != greetings.end())
+    {
+        if (Group* group = sender->GetGroup())
+        {
+            for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
+            {
+                if (Player* pMember = itr->getSource())
+                {
+                    if (pMember->GetGUIDLow() == playerGuid)
+                        continue;
+
+                    if (pMember->AI())
+                    {
+                        std::string greeting = *std::next(greetings.begin(), rand() % greetings.size());
+                        std::string response = (char)toupper(greeting[0]) + greeting.substr(1) + " " + playerName + "!";
+                        SendPartyChat(response.c_str(), pMember);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/game/PlayerBots/PartyBotChat.h
+++ b/src/game/PlayerBots/PartyBotChat.h
@@ -1,0 +1,35 @@
+#ifndef PARTY_BOT_CHAT_H
+#define PARTY_BOT_CHAT_H
+
+#include "Chat.h"
+#include "ObjectMgr.h"
+#include "WorldPacket.h"
+#include "ObjectGuid.h"
+#include "Player.h"
+#include "Group.h"
+
+
+
+class PartyBotChat
+{
+
+public:
+    static PartyBotChat* GetInstance();
+    void OnPacketReceived(WorldPacket const* packet);
+    void ProcessPartyMessage(ObjectGuid const& senderGuid, std::string const& message);
+    void SendPartyChat(const char* message, Player* player) const;
+    void HealerAnnounceTank(const char* msg, Player* player);
+    std::string GetHealerTankAnnouncementText(const char* pName, Player* player);
+
+    // Define greetings
+    static const std::set<std::string> greetings; 
+
+    bool HasHealerAnnouncedTank = false;
+
+private:
+    static PartyBotChat* instance;
+    PartyBotChat() {}
+    ~PartyBotChat() {}
+};
+
+#endif // PARTY_BOT_CHAT_H

--- a/src/game/PlayerBots/PartyBotChat.h
+++ b/src/game/PlayerBots/PartyBotChat.h
@@ -7,22 +7,54 @@
 #include "ObjectGuid.h"
 #include "Player.h"
 #include "Group.h"
+#include "World.h"
 
+static const char* GetPlayerClassName(uint8 playerClass)
+{
+    switch (playerClass)
+    {
+        case CLASS_WARRIOR:
+            return "Warrior";
+        case CLASS_PALADIN:
+            return "Paladin"; 
+        case CLASS_HUNTER:
+            return "Hunter";
+        case CLASS_ROGUE:
+            return "Rogue";
+        case CLASS_PRIEST:
+            return "Priest";
+        case CLASS_SHAMAN:
+            return "Shaman";
+        case CLASS_MAGE:
+            return "Mage";
+        case CLASS_WARLOCK:
+            return "Warlock";
+        case CLASS_DRUID:
+            return "Druid";
+        default:
+            return "Unknown";
+    }
+}
 
 
 class PartyBotChat
 {
 
 public:
+    static const std::vector<std::string> greetings; 
+    static const std::vector<std::string> insults;
+    static const std::vector<std::string> insultResponses;
+
     static PartyBotChat* GetInstance();
+    static std::string GetHealerTankAnnouncementText(const char* pName, Player* player);
+    static std::string GetInsult();
+    static std::string GetInsultResponse();
+
     void OnPacketReceived(WorldPacket const* packet);
     void ProcessPartyMessage(ObjectGuid const& senderGuid, std::string const& message);
     void SendPartyChat(const char* message, Player* player) const;
+    void SendPartyChat(const char* message, Player* player, float delay) const;
     void HealerAnnounceTank(const char* msg, Player* player);
-    std::string GetHealerTankAnnouncementText(const char* pName, Player* player);
-
-    // Define greetings
-    static const std::set<std::string> greetings; 
 
     bool HasHealerAnnouncedTank = false;
 

--- a/src/game/PlayerBots/PartyBotEncounters.cpp
+++ b/src/game/PlayerBots/PartyBotEncounters.cpp
@@ -2,6 +2,7 @@
 #include "Encounters/MoltenCore.h"
 
 bool PartyBotEncounters::m_overrideMeleePosition = false;
+bool PartyBotEncounters::m_overrideRangedPosition = false;
 bool PartyBotEncounters::m_overrideMagicDispel = false;
 
 bool PartyBotEncounters::IsEncounterInProgress(PartyBotAI* pBot)
@@ -21,9 +22,6 @@ bool PartyBotEncounters::HandleEncounterAI(PartyBotAI* pBot)
     if (!pBot || !pBot->me)
         return true;
 
-    if (!IsEncounterInProgress(pBot))
-        return true;
-
     switch (pBot->me->GetMap()->GetId())
     {
         case MAP_ID_MOLTEN_CORE:
@@ -33,4 +31,34 @@ bool PartyBotEncounters::HandleEncounterAI(PartyBotAI* pBot)
     }
 
     return true;
+}
+
+bool PartyBotEncounters::DispelMagic(PartyBotAI* pCaster, Unit* pTarget)
+{
+    if (!pCaster || !pTarget)
+        return false;
+
+    if (!pCaster->me->IsAlive())
+        return false;
+
+    uint8 pClass = pCaster->me->GetClass();
+    if (pClass != CLASS_PRIEST && pClass != CLASS_PALADIN)
+        return false;
+
+    uint32 spellId = (pClass == CLASS_PRIEST) ? SPELL_DISPEL_MAGIC : SPELL_CLEANSE;
+    std::string spellName = (pClass == CLASS_PRIEST) ? "Dispel Magic" : "Cleanse";
+    SpellEntry const* pSpell = sSpellMgr.GetSpellEntry(spellId);
+    if (Unit* pFriend = pCaster->SelectDispelTarget(pSpell))
+    {
+        if (pCaster->CanTryToCastSpell(pFriend, pSpell))
+        {
+            if (pCaster->DoCastSpell(pFriend, pSpell) == SPELL_CAST_OK)
+            {
+                pCaster->SendPartyChat(std::string(spellName).append(" cast on ").append(pFriend->GetName()).c_str());
+                return true;
+            }
+        }
+    }
+    
+    return false;
 }

--- a/src/game/PlayerBots/PartyBotEncounters.h
+++ b/src/game/PlayerBots/PartyBotEncounters.h
@@ -8,6 +8,11 @@
 #include "Spell.h"
 #include "ScriptedInstance.h"
 
+
+#define SPELL_DISPEL_MAGIC 988
+#define SPELL_CLEANSE 4987
+
+
 class PartyBotAI;  // Forward declaration
 
 class PartyBotEncounters
@@ -41,12 +46,16 @@ public:
     };
 
     static bool m_overrideMeleePosition;
+    static bool m_overrideRangedPosition;
     static bool m_overrideMagicDispel;
     static bool OverrideMeleePosition() { return m_overrideMeleePosition; }
+    static bool OverrideRangedPosition() { return m_overrideRangedPosition; }
     static bool OverrideMagicDispel() { return m_overrideMagicDispel; }
 
     static bool HandleEncounterAI(PartyBotAI* pBot);
     static bool IsEncounterInProgress(PartyBotAI* pBot);
+
+    static bool DispelMagic(PartyBotAI* pBot, Unit* pTarget);
 
     static void SendPartyChat(Player* player, const char* msg)
     {

--- a/src/game/PlayerBots/PartyBotEncounters.h
+++ b/src/game/PlayerBots/PartyBotEncounters.h
@@ -1,6 +1,13 @@
 #ifndef MANGOS_PartyBotEncounters_H
 #define MANGOS_PartyBotEncounters_H
 
+#include "SharedDefines.h"
+#include "MotionMaster.h"
+#include "Unit.h"
+#include "Player.h"
+#include "Spell.h"
+#include "ScriptedInstance.h"
+
 class PartyBotAI;  // Forward declaration
 
 class PartyBotEncounters
@@ -40,6 +47,11 @@ public:
 
     static bool HandleEncounterAI(PartyBotAI* pBot);
     static bool IsEncounterInProgress(PartyBotAI* pBot);
+
+    static void SendPartyChat(Player* player, const char* msg)
+    {
+        PartyBotChat::GetInstance()->SendPartyChat(msg, player);
+    }
 };
 
 #endif 

--- a/src/game/PlayerBots/PlayerBotMgr.cpp
+++ b/src/game/PlayerBots/PlayerBotMgr.cpp
@@ -1017,11 +1017,7 @@ bool PlayerBotMgr::CloneOfflinePlayer(Player* pPlayer, ObjectGuid guid)
     Player* newChar = new Player(sess);
     uint32 pguid = e->playerGUID;
 
-    // Set the player's name before creation
-    std::string botName = name.substr(0, std::min((size_t)7, name.length())) + "clone";
-    newChar->SetName(botName);
-    
-    if (!newChar->Create(pguid, botName, race, class_, gender, skin, face, hairStyle, hairColor, facialHair))
+    if (!newChar->Create(pguid, name, race, class_, gender, skin, face, hairStyle, hairColor, facialHair))
     {
         delete newChar;
         return false;


### PR DESCRIPTION
### 🆕 `PartyBotChat` System

 * A new singleton class `PartyBotChat` was added to contain all chat-related behavior for PartyBots to enhance maintainability and scalability for future chat-based behavior.
 * All chat-related functionality previously in `PartyBotAI` has been moved to `PartyBotChat`.
 * Bots will currently reply when you greet them. Just say hello in party chat!

<br>

### 🛠 `PartyBotEncounters` Improvements

* `MoltenCore.cpp`:
  * Moved #includes to `MoltenCore.h` for cleaner separation of concerns.
  * Removed checking for `SPECIAL` encounter state when determining instance encounter status.

<br>

### 📦 Build Configuration

* Added `PartyBotChat.cpp` to `CMakeLists.txt` &mdash; **you will need to run CMake before building**.
