### PR TITLE
Fixed bug in CloneOfflinePlayer that was preventing re-cloning of the same character more than once without a server restart

### DIFF
--- a/src/game/PlayerBots/PlayerBotMgr.cpp
+++ b/src/game/PlayerBots/PlayerBotMgr.cpp
@@ -1072,6 +1072,10 @@ bool PlayerBotMgr::CloneOfflinePlayer(Player* pPlayer, ObjectGuid guid)
     sObjectAccessor.AddObject(newChar);
     newChar->SetCanModifyStats(true);
 
+    // Reset the name-to-GUID mapping to point to the original character
+    // (Prevents "Error cloning player" when cloning a player that has already been cloned)
+    sObjectMgr.m_playerNameToGuid[name] = guid.GetCounter();
+
     // Clone skills
     result = CharacterDatabase.PQuery(
         "SELECT skill, value, max FROM character_skills WHERE guid = %u", 
@@ -1087,7 +1091,6 @@ bool PlayerBotMgr::CloneOfflinePlayer(Player* pPlayer, ObjectGuid guid)
             newChar->SetSkill(skillId, value, maxValue);
         } while (result->NextRow());
     }
-
 
     // Clone spells
     result = CharacterDatabase.PQuery(


### PR DESCRIPTION
## Description
When cloning an offline player using the `.partybot clone` command, subsequent attempts to clone the same character would fail with "Error cloning player". This occurred because the cloned bot's GUID was being stored in the `sObjectMgr`'s name-to-GUID mapping, preventing the original character data from being found in subsequent lookups.

## Root Cause
When creating a new bot, the `sObjectMgr`'s name-to-GUID mapping was being updated with the cloned bot's GUID, but this mapping was never restored to point to the original character. This caused subsequent queries for that character name to return the cloned bot's GUID instead of the original character's GUID, resulting in a failed database lookup when trying to clone the character again.

## Solution
The fix was to reset the name-to-GUID mapping immediately after creating the bot to point back to the original character's GUID. This ensures that any subsequent lookups for that character name will find the original GUID, allowing the same character to be cloned multiple times.