### PR TITLE
Add PartyBotEncounters framework for BWL

### DIFF
--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -195,7 +195,8 @@ set (game_SRCS
     PlayerBots/PartyBotChat.cpp
     PlayerBots/PartyBotEncounters.cpp
     PlayerBots/Encounters/MoltenCore.cpp
-    PlayerBots/Encounters/ZulGurub.cpp    
+    PlayerBots/Encounters/ZulGurub.cpp
+    PlayerBots/Encounters/BlackwingLair.cpp    
     PlayerBots/CombatBotBaseAI.cpp
     PlayerBots/BattleBotAI.cpp
     PlayerBots/BattleBotWaypoints.cpp

--- a/src/game/PlayerBots/Encounters/BlackwingLair.cpp
+++ b/src/game/PlayerBots/Encounters/BlackwingLair.cpp
@@ -1,0 +1,213 @@
+#include "BlackwingLair.h"
+#include "PlayerBots/PartyBotChat.h"
+#include "AI/ScriptedInstance.h"
+#include "Group/Group.h"
+
+
+void PartyBotEncounters_BWL::ResetEncounterVars()
+{
+    PartyBotEncounters::ResetEncounterVars();
+}
+
+
+bool PartyBotEncounters_BWL::HandleEncounterAI(PartyBotAI* pBot)
+{
+    Player* pPlayer = pBot->me;
+    if (!pPlayer)
+        return true;
+
+    ScriptedInstance* pInstance = (ScriptedInstance*)pPlayer->GetInstanceData();
+    if (!pInstance)
+        return true;
+
+    uint32 razorgoreState = pInstance->GetData(TYPE_RAZORGORE);
+    uint32 vaelastraszState = pInstance->GetData(TYPE_VAELASTRASZ);
+    uint32 broodlordState = pInstance->GetData(TYPE_BROODLORD);
+    uint32 firemawState = pInstance->GetData(TYPE_FIREMAW);
+    uint32 ebonrocState = pInstance->GetData(TYPE_EBONROC);
+    uint32 flamegorState = pInstance->GetData(TYPE_FLAMEGOR);
+    uint32 chromaggusState = pInstance->GetData(TYPE_CHROMAGGUS);
+    uint32 nefarianState = pInstance->GetData(TYPE_NEFARIAN);
+
+    // Check if any encounter is in progress
+    bool anyEncounterInProgress = 
+        (razorgoreState == IN_PROGRESS) ||
+        (vaelastraszState == IN_PROGRESS) ||
+        (broodlordState == IN_PROGRESS) ||
+        (firemawState == IN_PROGRESS) ||
+        (ebonrocState == IN_PROGRESS) ||
+        (flamegorState == IN_PROGRESS) ||
+        (chromaggusState == IN_PROGRESS) ||
+        (nefarianState == IN_PROGRESS);
+
+    if (!anyEncounterInProgress && !pBot->me->IsInCombat())
+        ResetEncounterVars();
+    
+    if (razorgoreState == IN_PROGRESS)
+    {
+        return RazorgoreEncounter(pBot);
+    }
+    else if (vaelastraszState == IN_PROGRESS)
+    {
+        return VaelastraszEncounter(pBot);
+    }
+    else if (broodlordState == IN_PROGRESS)
+    {
+        return BroodlordEncounter(pBot);
+    }
+    else if (firemawState == IN_PROGRESS)
+    {
+        return FiremawEncounter(pBot);
+    }
+    else if (ebonrocState == IN_PROGRESS)
+    {
+        return EbonrocEncounter(pBot);
+    }
+    else if (flamegorState == IN_PROGRESS)
+    {
+        return FlamegorEncounter(pBot);
+    }
+    else if (chromaggusState == IN_PROGRESS)
+    {
+        return ChromaggusEncounter(pBot);
+    }
+    else if (nefarianState == IN_PROGRESS)
+    {
+        return NefarianEncounter(pBot);
+    }
+    else if (pBot->me->IsInCombat())
+    {
+        return TrashEncounter(pBot);
+    }
+
+    return true;
+}
+
+
+bool PartyBotEncounters_BWL::TrashEncounter(PartyBotAI* pBot)
+{
+    return true;
+}
+
+
+bool PartyBotEncounters_BWL::RazorgoreEncounter(PartyBotAI* pBot)
+{
+    Player* pPlayer = pBot->me;
+    if (!pPlayer)
+        return true;
+
+    ScriptedInstance* pInstance = (ScriptedInstance*)pPlayer->GetInstanceData();
+    if (!pInstance)
+        return true;
+
+    uint32 eggsDestroyed = pInstance->GetData(RAZORGORE_EGGS_DESTROYED);
+    
+    if (eggsDestroyed >= 15)
+        return true;
+
+    // Define focus mobs within 100 yards
+    std::list<Creature*> mages;
+    std::list<Creature*> legionnaires;
+    std::list<Creature*> dragonspawns;
+    pPlayer->GetCreatureListWithEntryInGrid(mages, BLACKWING_MAGE, 100.0f);
+    pPlayer->GetCreatureListWithEntryInGrid(legionnaires, BLACKWING_LEGIONNAIRE, 100.0f);
+    pPlayer->GetCreatureListWithEntryInGrid(dragonspawns, DEATH_TALON_DRAGONSPAWN, 100.0f);
+    
+    // Ignore dead mobs
+    mages.remove_if([](Creature* creature) { return !creature || !creature->IsAlive(); });
+    legionnaires.remove_if([](Creature* creature) { return !creature || !creature->IsAlive(); });
+    dragonspawns.remove_if([](Creature* creature) { return !creature || !creature->IsAlive(); });
+    
+    if (!mages.empty() || !legionnaires.empty() || !dragonspawns.empty())
+    {
+        bool assist = false;
+        if (Group* pGroup = pPlayer->GetGroup())
+        {
+            // Check if any group member is already targeting a focus mob
+            for (GroupReference* itr = pGroup->GetFirstMember(); itr != nullptr; itr = itr->next())
+            {
+                if (Player* member = itr->getSource())
+                {
+                    if (member != pPlayer && member->IsAlive())
+                    {
+                        if (Unit* memberTarget = member->GetVictim())
+                        {
+                            if ((memberTarget->GetEntry() == BLACKWING_MAGE || 
+                                 memberTarget->GetEntry() == BLACKWING_LEGIONNAIRE ||
+                                 memberTarget->GetEntry() == DEATH_TALON_DRAGONSPAWN) && 
+                                 memberTarget->IsAlive() &&
+                                 pPlayer->GetVictim() != memberTarget)
+                            {
+                                pPlayer->SetTargetGuid(memberTarget->GetObjectGuid());
+                                assist = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // If no one is targeting a focus mob, pick the first available one
+            if (!assist)
+            {
+                Creature* target = nullptr;
+                if (!mages.empty())
+                    target = mages.front();
+                else if (!legionnaires.empty())
+                    target = legionnaires.front();
+                else if (!dragonspawns.empty())
+                    target = dragonspawns.front();
+                
+                if (target && pPlayer->GetVictim() != target)
+                {
+                    pBot->SendPartyChat(("Focusing on " + std::string(target->GetName()) + "!").c_str());
+                    pPlayer->SetTargetGuid(target->GetObjectGuid());
+                }
+            }
+        }
+    }
+
+    return true;
+}
+
+
+bool PartyBotEncounters_BWL::VaelastraszEncounter(PartyBotAI* pBot)
+{
+    return true;
+}
+
+
+bool PartyBotEncounters_BWL::BroodlordEncounter(PartyBotAI* pBot)
+{
+    return true;
+}
+
+
+bool PartyBotEncounters_BWL::FiremawEncounter(PartyBotAI* pBot)
+{
+    return true;
+}
+
+
+bool PartyBotEncounters_BWL::EbonrocEncounter(PartyBotAI* pBot)
+{
+    return true;
+}
+
+
+bool PartyBotEncounters_BWL::FlamegorEncounter(PartyBotAI* pBot)
+{
+    return true;
+}
+
+
+bool PartyBotEncounters_BWL::ChromaggusEncounter(PartyBotAI* pBot)
+{
+    return true;
+}
+
+
+bool PartyBotEncounters_BWL::NefarianEncounter(PartyBotAI* pBot)
+{
+    return true;
+}

--- a/src/game/PlayerBots/Encounters/BlackwingLair.h
+++ b/src/game/PlayerBots/Encounters/BlackwingLair.h
@@ -1,0 +1,41 @@
+#include "PartyBotAI.h"
+#include "PartyBotEncounters.h"
+
+// Razorgore
+#define RAZORGORE 12435
+#define RAZORGORE_EGGS_DESTROYED 13    // scriptedInstance 
+#define DEATH_TALON_DRAGONSPAWN 12422
+#define BLACKWING_MAGE 12420
+#define BLACKWING_LEGIONNAIRE 12416
+
+enum BWL_EncounterIds
+{
+    TYPE_RAZORGORE = 0,
+    TYPE_VAELASTRASZ = 1,
+    TYPE_BROODLORD = 2,
+    TYPE_FIREMAW = 3,
+    TYPE_EBONROC = 4,
+    TYPE_FLAMEGOR = 5,
+    TYPE_CHROMAGGUS = 6,
+    TYPE_NEFARIAN = 7
+};
+
+
+    
+class PartyBotEncounters_BWL : public PartyBotEncounters
+{
+public:
+    static bool HandleEncounterAI(PartyBotAI* pBot);
+    
+    static bool RazorgoreEncounter(PartyBotAI* pBot);
+    static bool VaelastraszEncounter(PartyBotAI* pBot);
+    static bool BroodlordEncounter(PartyBotAI* pBot);
+    static bool FiremawEncounter(PartyBotAI* pBot);
+    static bool EbonrocEncounter(PartyBotAI* pBot);
+    static bool FlamegorEncounter(PartyBotAI* pBot);
+    static bool ChromaggusEncounter(PartyBotAI* pBot);
+    static bool NefarianEncounter(PartyBotAI* pBot);
+    static bool TrashEncounter(PartyBotAI* pBot);
+
+    static void ResetEncounterVars();
+};

--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -4054,3 +4054,17 @@ void PartyBotAI::SetChatCooldown(uint32 seconds)
 
     PartyBotChat::GetInstance()->SetPartyBotCooldown(me->GetObjectGuid(), seconds);
 }
+
+void PartyBotAI::AutoAssignRole()
+{
+    CombatBotBaseAI::AutoAssignRole();
+    
+    // Add skull mark to focus list for DPS roles
+    if (m_role == ROLE_MELEE_DPS || m_role == ROLE_RANGE_DPS)
+    {
+        if (std::find(m_marksToFocus.begin(), m_marksToFocus.end(), RAID_TARGET_ICON_SKULL) == m_marksToFocus.end())
+        {
+            m_marksToFocus.push_back(RAID_TARGET_ICON_SKULL);
+        }
+    }
+}

--- a/src/game/PlayerBots/PartyBotAI.h
+++ b/src/game/PlayerBots/PartyBotAI.h
@@ -106,6 +106,8 @@ public:
     void UpdateInCombatAI_Druid() final;
     void UpdateOutOfCombatAI_Druid() final;
 
+    void AutoAssignRole();
+
     bool IsStaying() const { return m_isStaying; }
     void SetStaying(bool staying);
     void RepositionMeleeDps();

--- a/src/game/PlayerBots/PartyBotChat.cpp
+++ b/src/game/PlayerBots/PartyBotChat.cpp
@@ -253,34 +253,42 @@ void PartyBotChat::ProcessPartyMessage(ObjectGuid const& senderGuid, std::string
     // Who is the pLeader
     if (msg.find("who's your daddy") != std::string::npos)
     {
-        if (PartyBotAI* pAI = dynamic_cast<PartyBotAI*>(sender->AI()))
+        if (Group* group = sender->GetGroup())
         {
-            char message[128];
-            Player* pLeader = ObjectAccessor::FindPlayer(pAI->m_leaderGuid);
-            if (pLeader)
+            for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
             {
-                if(pLeader->GetDeathState() == DEAD)
+                if (Player* pMember = itr->getSource())
                 {
-                    snprintf(message, sizeof(message), "My daddy, for your fuckin information, is DEAD, asshole. Lol jk, it's %s.", pLeader->GetName());
-                    SendPartyChat(message, sender);
-                    return;
+                    if (pMember->GetGUIDLow() == playerGuid)
+                        continue;
+
+                    if(PartyBotAI* pAI = dynamic_cast<PartyBotAI*>(pMember->AI()))
+                    {
+                        char message[128];
+                        Player* pLeader = ObjectAccessor::FindPlayer(pAI->m_leaderGuid);
+                        if(pLeader)
+                        {
+
+                            if(pLeader->GetDeathState() == DEAD)
+                            {
+                                snprintf(message, sizeof(message), "My daddy, for your fuckin information, is DEAD, asshole. Lol jk, it's %s.", pLeader->GetName());
+                                SendPartyChat(message, pMember);
+                            }
+                            else
+                            {
+                                const char* messages[] = {
+                                    "%s is my leader and I follow them with unwavering loyalty.",
+                                    "I serve %s, they are my absolute lordingheimenschmiggdt.",
+                                    "I'm %s's bitch, and I'm proud of it.",
+                                    "My daddy is %s."
+                                };
+                                const char* selectedMessage = messages[urand(0,2)];
+                                snprintf(message, sizeof(message), selectedMessage, pLeader->GetName());
+                                SendPartyChat(message, pMember);
+                            }
+                        }
+                    }
                 }
-                else
-                {
-                    const char* messages[] = {
-                        "%s is my leader and I follow them with unwavering loyalty.",
-                        "I serve %s, they are my absolute lordingheimenschmiggdt.",
-                        "I'm %s's bitch, and I'm proud of it.",
-                    };
-                    const char* selectedMessage = messages[urand(0,2)];
-                    snprintf(message, sizeof(message), selectedMessage, pLeader->GetName());
-                    SendPartyChat(message, sender);
-                }
-            }
-            else
-            {
-                snprintf(message, sizeof(message), "I don't know who my daddy is, %s.", sender->GetName());
-                SendPartyChat(message, sender);
             }
         }
     }

--- a/src/game/PlayerBots/PartyBotEncounters.cpp
+++ b/src/game/PlayerBots/PartyBotEncounters.cpp
@@ -1,6 +1,7 @@
 #include "ScriptedInstance.h"
 #include "Encounters/MoltenCore.h"
 #include "Encounters/ZulGurub.h"
+#include "Encounters/BlackwingLair.h"
 
 bool PartyBotEncounters::m_overrideMeleePosition = false;
 bool PartyBotEncounters::m_overrideRangedPosition = false;
@@ -32,6 +33,10 @@ bool PartyBotEncounters::HandleEncounterAI(PartyBotAI* pBot)
         case MAP_ID_ZUL_GURUB:
         {
             return PartyBotEncounters_ZG::HandleEncounterAI(pBot);
+        }
+        case MAP_ID_BLACKWING_LAIR:
+        {
+            return PartyBotEncounters_BWL::HandleEncounterAI(pBot);
         }
     }
 

--- a/src/game/PlayerBots/PlayerBotMgr.cpp
+++ b/src/game/PlayerBots/PlayerBotMgr.cpp
@@ -1331,6 +1331,16 @@ bool ChatHandler::HandlePartyBotSetRoleCommand(char* args)
             pAI->m_role = role;
             pAI->ResetSpellData();
             pAI->PopulateSpellData();
+            
+            // Add skull mark to DPS bots' focus list by default
+            if (role == ROLE_MELEE_DPS || role == ROLE_RANGE_DPS)
+            {
+                if (std::find(pAI->m_marksToFocus.begin(), pAI->m_marksToFocus.end(), RAID_TARGET_ICON_SKULL) == pAI->m_marksToFocus.end())
+                {
+                    pAI->m_marksToFocus.push_back(RAID_TARGET_ICON_SKULL);
+                }
+            }
+            
             PSendSysMessage("%s is now a %s.", pTarget->GetName(), roleStr.c_str());
             return true;
         }


### PR DESCRIPTION
Added PartyBotEncounters logic for Blackwing Lair.

Skull focus mark will automatically be assigned to DPS bots.