### PR TITLE
Ranged bots will stack during the BWL broodlord trash gauntlet

### DIFF
--- a/src/game/PlayerBots/Encounters/BlackwingLair.cpp
+++ b/src/game/PlayerBots/Encounters/BlackwingLair.cpp
@@ -86,6 +86,38 @@ bool PartyBotEncounters_BWL::HandleEncounterAI(PartyBotAI* pBot)
 
 bool PartyBotEncounters_BWL::TrashEncounter(PartyBotAI* pBot)
 {
+    Player* pPlayer = pBot->me;
+    if (!pPlayer)
+        return true;
+    
+    // Search for broodlord trash within 40 yards
+    std::list<Creature*> broodlordTrash;
+    pPlayer->GetCreatureListWithEntryInGrid(broodlordTrash, DEATH_TALON_HATCHER, 40.0f);
+    pPlayer->GetCreatureListWithEntryInGrid(broodlordTrash, CORRUPTED_GREEN_WHELP, 40.0f);
+    pPlayer->GetCreatureListWithEntryInGrid(broodlordTrash, CORRUPTED_RED_WHELP, 40.0f);
+    pPlayer->GetCreatureListWithEntryInGrid(broodlordTrash, CORRUPTED_BLUE_WHELP, 40.0f);
+    pPlayer->GetCreatureListWithEntryInGrid(broodlordTrash, CORRUPTED_BRONZE_WHELP, 40.0f);
+    broodlordTrash.remove_if([](Creature* creature) { return !creature || !creature->IsAlive(); });
+    if (!broodlordTrash.empty())
+    {
+        // Ranged DPS and healer bots should stack on owner
+        if (pBot->GetRole() == ROLE_RANGE_DPS || pBot->GetRole() == ROLE_HEALER)
+        {
+            Player* pOwner = ObjectAccessor::FindPlayer(pBot->m_leaderGuid);
+            if (pOwner && pOwner->IsAlive() && pPlayer->GetDistance(pOwner) > 5.0f)
+            {
+                pPlayer->StopMoving();
+                pPlayer->GetMotionMaster()->Clear(false, true);
+                pPlayer->GetMotionMaster()->MoveFollow(pOwner, 3.0f, 0.0f);
+                pPlayer->SetCasterChaseDistance(5.0f);
+                m_overrideRangedPosition = true;
+                return false;
+            }
+        }
+    } else {
+        m_overrideRangedPosition = false;
+    }
+
     return true;
 }
 

--- a/src/game/PlayerBots/Encounters/BlackwingLair.h
+++ b/src/game/PlayerBots/Encounters/BlackwingLair.h
@@ -8,6 +8,14 @@
 #define BLACKWING_MAGE 12420
 #define BLACKWING_LEGIONNAIRE 12416
 
+// Broodlord trash
+#define DEATH_TALON_HATCHER 12468
+#define CORRUPTED_GREEN_WHELP  14023
+#define CORRUPTED_RED_WHELP    14022
+#define CORRUPTED_BLUE_WHELP   14024
+#define CORRUPTED_BRONZE_WHELP 14025
+
+
 enum BWL_EncounterIds
 {
     TYPE_RAZORGORE = 0,
@@ -20,8 +28,6 @@ enum BWL_EncounterIds
     TYPE_NEFARIAN = 7
 };
 
-
-    
 class PartyBotEncounters_BWL : public PartyBotEncounters
 {
 public:

--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -1947,8 +1947,10 @@ void PartyBotAI::UpdateInCombatAI_Mage()
                     if (DoCastSpell(me, m_spells.mage.pBlink) == SPELL_CAST_OK)
                         return;
                 }
+            
 
-                if (!me->HasUnitState(UNIT_STATE_CAN_NOT_MOVE))
+        if (!me->HasUnitState(UNIT_STATE_CAN_NOT_MOVE) &&
+            !PartyBotEncounters::OverrideRangedPosition())
         {
             if (m_spells.mage.pFrostNova &&
                 !pVictim->HasUnitState(UNIT_STATE_ROOT) &&
@@ -3611,7 +3613,7 @@ void PartyBotAI::UpdateInCombatAI_Druid()
             if (me->GetMotionMaster()->GetCurrentMovementGeneratorType() == IDLE_MOTION_TYPE &&
                 me->GetDistance(pVictim) > 35.0f)
             {
-                if (!m_isStaying)
+                if (!m_isStaying && !PartyBotEncounters::OverrideRangedPosition())
                 {
                     me->GetMotionMaster()->MoveChase(pVictim, 30.0f);
                 }
@@ -3619,7 +3621,8 @@ void PartyBotAI::UpdateInCombatAI_Druid()
             else if (pVictim->CanReachWithMeleeAutoAttack(me) &&
                     (pVictim->GetVictim() == me) &&
                     !me->HasUnitState(UNIT_STATE_ROOT) &&
-                    (me->GetMotionMaster()->GetCurrentMovementGeneratorType() != DISTANCING_MOTION_TYPE))
+                    (me->GetMotionMaster()->GetCurrentMovementGeneratorType() != DISTANCING_MOTION_TYPE) &&
+                    !PartyBotEncounters::OverrideRangedPosition())
             {
                 if (m_spells.druid.pEntanglingRoots &&
                     CanTryToCastSpell(pVictim, m_spells.druid.pEntanglingRoots))


### PR DESCRIPTION
Healer and ranged dps bots will stack on their owner (within 5 yd) whenever any Death Talon Hatcher or Corrupted Whelp is within 40 yards of them.

Not tested in game.