### PR TITLE
PartyBots Priorities for Actions Over Drinking/Eating (#18)

### DIFF
--- a/README_FOR_BUILD.md
+++ b/README_FOR_BUILD.md
@@ -1,0 +1,224 @@
+# Lavender Dreams - Windows Build Instructions
+
+This guide will help you build the Lavender Dreams server on Windows using Visual Studio 2022 and CMake 4.0.0.
+
+## Setup Instructions
+
+### Step 1: Clone the Repository
+
+First, clone the Lavender Dreams repository:
+
+```powershell
+cd C:\
+git clone https://github.com/Lexaraj/LavenderDreams.git LavenderDreams
+cd LavenderDreams
+```
+
+### Step 2: Download External Libraries
+
+- Get ACE Wrappers from https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-8_0_5/ACE+TAO-8.0.5.zip
+
+- Get TBB from https://github.com/uxlfoundation/oneTBB/releases/download/v2022.3.0/oneapi-tbb-2022.3.0-win.zip
+
+- Extract the libraries into your root folder under `ACE_wrappers` and `tbb` respectively.
+
+After extraction, your folder structure should look like:
+```
+C:\LavenderDreams\
+├── src\                    (from git)
+├── dep\                    (from git)
+├── cmake\                  (from git)
+├── sql\                    (from git)
+├── contrib\                (from git)
+├── CMakeLists.txt          (from git)
+├── ACE_wrappers\           (from zip)
+│   ├── ace\
+│   └── lib\
+├── tbb\                    (from zip)
+│   ├── include\
+│   └── lib\
+```
+
+### Step 3: Set Environment Variables
+
+You need to tell CMake where to find ACE and TBB.
+
+**Option A: Using PowerShell (Recommended - Permanent)**
+
+Open PowerShell as Administrator and run:
+
+```powershell
+# Replace C:\LavenderDreams with your actual extraction path
+setx ACE_ROOT "C:\LavenderDreams\ACE_wrappers"
+setx TBB_ROOT "C:\LavenderDreams\tbb"
+```
+
+**Option B: Using System Properties GUI (Permanent)**
+
+1. Press `Windows Key + Pause/Break` (or right-click "This PC" → Properties)
+2. Click "Advanced system settings" in the right panel
+3. Click "Environment Variables"
+4. Under "System variables", click "New"
+5. Add these two variables:
+   - Variable name: `ACE_ROOT`
+     Variable value: `C:\LavenderDreams\ACE_wrappers` (use your actual path)
+   - Variable name: `TBB_ROOT`
+     Variable value: `C:\LavenderDreams\tbb` (use your actual path)
+6. Click OK on all dialogs
+
+**Option C: Temporary (Just for This Session)**
+
+In PowerShell:
+```powershell
+$env:ACE_ROOT="C:\LavenderDreams\ACE_wrappers"
+$env:TBB_ROOT="C:\LavenderDreams\tbb"
+```
+
+
+### Step 4: Verify Your Setup
+
+Open a **new** PowerShell window and run:
+
+```powershell
+cmake --version
+git --version
+echo $env:ACE_ROOT
+echo $env:TBB_ROOT
+```
+
+You should see:
+- CMake version 3.16 or higher
+- Git version information
+- The path to your ACE_wrappers folder
+- The path to your tbb folder
+
+If any of these are empty or show "not found", go back to the appropriate step.
+
+---
+
+## Building the Project
+
+### Method 1: Using Visual Studio
+
+#### Step 1: Open the Project
+
+1. Open Visual Studio 2022
+2. Click "Open a local folder"
+3. Navigate to and select your `C:\LavenderDreams` folder
+
+Visual Studio will automatically detect the CMake project.
+
+#### Step 2: Configure CMake
+
+1. Wait for Visual Studio to finish loading (you'll see "CMake generation finished" in the output)
+2. If you see any errors about ACE or TBB not found:
+   - Make sure environment variables are set correctly
+   - Close and reopen Visual Studio
+   - Or use Method 2 below to specify paths manually
+
+#### Step 3: Build
+
+1. At the top of Visual Studio, select **"x64-Release"** from the configuration dropdown
+2. Go to menu: **Build → Build All** (or press `Ctrl+Shift+B`)
+3. Wait for the build to complete (this may take 10-20 minutes on first build)
+
+#### Step 4: Find Your Binaries
+
+After successful build, your executables will be in:
+```
+C:\LavenderDreams\out\build\x64-Release\
+```
+
+Look for:
+- `mangosd.exe` - Game server
+- `realmd.exe` - Login/realm server
+
+### Method 2: Using Command Line (More Control)
+
+#### Step 1: Open PowerShell
+
+Right-click on your project folder and select "Open in Windows Terminal" or "Open PowerShell window here"
+
+Or open PowerShell and navigate:
+```powershell
+cd C:\LavenderDreams
+```
+
+#### Step 2: Create Build Directory
+
+```powershell
+mkdir build
+cd build
+```
+
+#### Step 3: Configure with CMake
+
+**Basic Configuration:**
+```powershell
+cmake .. -G "Visual Studio 17 2022" -A x64
+```
+
+**If ACE_ROOT or TBB_ROOT aren't detected, specify them explicitly:**
+```powershell
+cmake .. -G "Visual Studio 17 2022" -A x64 `
+  -DACE_ROOT="C:\LavenderDreams\ACE_wrappers" `
+  -DTBB_ROOT="C:\LavenderDreams\tbb"
+```
+
+**Optional: Specify custom install location:**
+```powershell
+cmake .. -G "Visual Studio 17 2022" -A x64 `
+  -DCMAKE_INSTALL_PREFIX="C:\LavenderDreams\server"
+```
+
+You should see output similar to:
+```
+-- Found ACE library: C:/LavenderDreams/ACE_wrappers/lib/ACE.lib
+-- Found ACE headers: C:/LavenderDreams/ACE_wrappers
+-- Memory allocation: TBB/Release
+-- Configuring done
+-- Generating done
+```
+
+#### Step 4: Build the Project
+
+**Build Release version (recommended):**
+```powershell
+cmake --build . --config Release
+```
+
+**Or build with Visual Studio:**
+```powershell
+# This opens the solution in Visual Studio
+start MaNGOS.sln
+```
+
+Then in Visual Studio:
+1. Select **Release** configuration (dropdown at top)
+2. Select **x64** platform
+3. Build → Build Solution (F7)
+
+#### Step 5: Install (Optional)
+
+This copies the executables and DLLs to your install directory:
+```powershell
+cmake --install . --config Release
+```
+
+#### Step 6: Find Your Binaries
+
+After build, executables will be in one of these locations:
+
+**If you built without install:**
+```
+C:\LavenderDreams\build\src\mangosd\Release\mangosd.exe
+C:\LavenderDreams\build\src\realmd\Release\realmd.exe
+```
+
+**If you ran install:**
+```
+C:\LavenderDreams\server\mangosd.exe
+C:\LavenderDreams\server\realmd.exe
+```
+
+

--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -197,6 +197,17 @@ bool PartyBotAI::DrinkAndEat()
     if (me->GetVictim())
         return false;
 
+    // Healers should not start drinking if there are dead allies to resurrect
+    if (GetRole() == ROLE_HEALER && m_resurrectionSpell && !IsInDuel())
+    {
+        if (Player* pTarget = SelectResurrectionTarget())
+        {
+            // Only skip drinking if we can cast resurrection (have enough mana)
+            if (CanTryToCastSpell(pTarget, m_resurrectionSpell))
+                return false;
+        }
+    }
+
     bool const needToEat = me->GetHealthPercent() < 95.0f;
     bool const needToDrink = (me->GetPowerType() == POWER_MANA) && (me->GetPowerPercent(POWER_MANA) < 95.0f);
 
@@ -900,6 +911,29 @@ void PartyBotAI::UpdateAI(uint32 const diff)
 
     if (!me->IsInCombat())
     {
+        // Healers should prioritize resurrection over drinking
+        if (GetRole() == ROLE_HEALER && m_resurrectionSpell && !IsInDuel())
+        {
+            if (Player* pTarget = SelectResurrectionTarget())
+            {
+                if (CanTryToCastSpell(pTarget, m_resurrectionSpell))
+                {
+                    // Stop drinking/eating to cast resurrection
+                    if (me->HasAura(PB_SPELL_DRINK))
+                        me->RemoveAurasDueToSpell(PB_SPELL_DRINK);
+                    if (me->HasAura(PB_SPELL_FOOD))
+                        me->RemoveAurasDueToSpell(PB_SPELL_FOOD);
+                    
+                    // Stand up if sitting
+                    if (me->GetStandState() != UNIT_STAND_STATE_STAND)
+                        me->SetStandState(UNIT_STAND_STATE_STAND);
+                    
+                    if (DoCastSpell(pTarget, m_resurrectionSpell) == SPELL_CAST_OK)
+                        return;
+                }
+            }
+        }
+
         if (DrinkAndEat())
         {
             if (!me->IsWithinDistInMap(pLeader, 100.0f))

--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -208,6 +208,14 @@ bool PartyBotAI::DrinkAndEat()
         }
     }
 
+    // All bots should not start drinking if there are allies to dispel
+    if (NeedsToDispelAlly())
+        return false;
+
+    // All bots should not start drinking if there are allies to buff
+    if (NeedsToBuffAlly())
+        return false;
+
     bool const needToEat = me->GetHealthPercent() < 95.0f;
     bool const needToDrink = (me->GetPowerType() == POWER_MANA) && (me->GetPowerPercent(POWER_MANA) < 95.0f);
 
@@ -550,6 +558,588 @@ Player* PartyBotAI::SelectResurrectionTarget() const
     }
 
     return nullptr;
+}
+
+bool PartyBotAI::NeedsToDispelAlly() const
+{
+    if (IsInDuel())
+        return false;
+
+    // Check if bot has any dispel spell available
+    SpellEntry const* pDispelSpell = nullptr;
+    
+    switch (me->GetClass())
+    {
+        case CLASS_PALADIN:
+            pDispelSpell = m_spells.paladin.pCleanse;
+            break;
+        case CLASS_SHAMAN:
+            // Shaman has multiple dispels, check them in priority order
+            if (m_spells.shaman.pCureDisease)
+                if (SelectDispelTarget(m_spells.shaman.pCureDisease))
+                    if (CanTryToCastSpell(SelectDispelTarget(m_spells.shaman.pCureDisease), m_spells.shaman.pCureDisease))
+                        return true;
+            if (m_spells.shaman.pCurePoison)
+                if (SelectDispelTarget(m_spells.shaman.pCurePoison))
+                    if (CanTryToCastSpell(SelectDispelTarget(m_spells.shaman.pCurePoison), m_spells.shaman.pCurePoison))
+                        return true;
+            return false;
+        case CLASS_MAGE:
+            pDispelSpell = m_spells.mage.pRemoveLesserCurse;
+            break;
+        case CLASS_PRIEST:
+            // Priest has multiple dispels, check them in priority order
+            if (m_spells.priest.pDispelMagic && !PartyBotEncounters::OverrideMagicDispel())
+                if (SelectDispelTarget(m_spells.priest.pDispelMagic))
+                    if (CanTryToCastSpell(SelectDispelTarget(m_spells.priest.pDispelMagic), m_spells.priest.pDispelMagic))
+                        return true;
+            if (m_spells.priest.pAbolishDisease)
+                if (SelectDispelTarget(m_spells.priest.pAbolishDisease))
+                    if (CanTryToCastSpell(SelectDispelTarget(m_spells.priest.pAbolishDisease), m_spells.priest.pAbolishDisease))
+                        return true;
+            return false;
+        case CLASS_DRUID:
+            // Druid has multiple dispels, check them in priority order
+            if (m_spells.druid.pAbolishPoison)
+                if (SelectDispelTarget(m_spells.druid.pAbolishPoison))
+                    if (CanTryToCastSpell(SelectDispelTarget(m_spells.druid.pAbolishPoison), m_spells.druid.pAbolishPoison))
+                        return true;
+            if (m_spells.druid.pRemoveCurse)
+                if (SelectDispelTarget(m_spells.druid.pRemoveCurse))
+                    if (CanTryToCastSpell(SelectDispelTarget(m_spells.druid.pRemoveCurse), m_spells.druid.pRemoveCurse))
+                        return true;
+            return false;
+        default:
+            return false;
+    }
+
+    // For classes with a single dispel spell
+    if (pDispelSpell)
+    {
+        if (Player* pTarget = SelectDispelTarget(pDispelSpell))
+        {
+            if (CanTryToCastSpell(pTarget, pDispelSpell))
+                return true;
+        }
+    }
+
+    return false;
+}
+
+bool PartyBotAI::TryDispelAlly()
+{
+    if (IsInDuel())
+        return false;
+
+    // Try each class's dispel spells
+    switch (me->GetClass())
+    {
+        case CLASS_PALADIN:
+            if (m_spells.paladin.pCleanse)
+            {
+                if (Player* pTarget = SelectDispelTarget(m_spells.paladin.pCleanse))
+                {
+                    if (CanTryToCastSpell(pTarget, m_spells.paladin.pCleanse))
+                    {
+                        if (DoCastSpell(pTarget, m_spells.paladin.pCleanse) == SPELL_CAST_OK)
+                            return true;
+                    }
+                }
+            }
+            break;
+        case CLASS_SHAMAN:
+            if (m_spells.shaman.pCureDisease)
+            {
+                if (Player* pTarget = SelectDispelTarget(m_spells.shaman.pCureDisease))
+                {
+                    if (CanTryToCastSpell(pTarget, m_spells.shaman.pCureDisease))
+                    {
+                        if (DoCastSpell(pTarget, m_spells.shaman.pCureDisease) == SPELL_CAST_OK)
+                            return true;
+                    }
+                }
+            }
+            if (m_spells.shaman.pCurePoison)
+            {
+                if (Player* pTarget = SelectDispelTarget(m_spells.shaman.pCurePoison))
+                {
+                    if (CanTryToCastSpell(pTarget, m_spells.shaman.pCurePoison))
+                    {
+                        if (DoCastSpell(pTarget, m_spells.shaman.pCurePoison) == SPELL_CAST_OK)
+                            return true;
+                    }
+                }
+            }
+            break;
+        case CLASS_MAGE:
+            if (m_spells.mage.pRemoveLesserCurse)
+            {
+                if (Player* pTarget = SelectDispelTarget(m_spells.mage.pRemoveLesserCurse))
+                {
+                    if (CanTryToCastSpell(pTarget, m_spells.mage.pRemoveLesserCurse))
+                    {
+                        if (DoCastSpell(pTarget, m_spells.mage.pRemoveLesserCurse) == SPELL_CAST_OK)
+                            return true;
+                    }
+                }
+            }
+            break;
+        case CLASS_PRIEST:
+            if (m_spells.priest.pDispelMagic && !PartyBotEncounters::OverrideMagicDispel())
+            {
+                if (Player* pTarget = SelectDispelTarget(m_spells.priest.pDispelMagic))
+                {
+                    if (CanTryToCastSpell(pTarget, m_spells.priest.pDispelMagic))
+                    {
+                        if (DoCastSpell(pTarget, m_spells.priest.pDispelMagic) == SPELL_CAST_OK)
+                            return true;
+                    }
+                }
+            }
+            if (m_spells.priest.pAbolishDisease)
+            {
+                if (Player* pTarget = SelectDispelTarget(m_spells.priest.pAbolishDisease))
+                {
+                    if (CanTryToCastSpell(pTarget, m_spells.priest.pAbolishDisease))
+                    {
+                        if (DoCastSpell(pTarget, m_spells.priest.pAbolishDisease) == SPELL_CAST_OK)
+                            return true;
+                    }
+                }
+            }
+            break;
+        case CLASS_DRUID:
+            if (m_spells.druid.pAbolishPoison)
+            {
+                if (Player* pTarget = SelectDispelTarget(m_spells.druid.pAbolishPoison))
+                {
+                    if (CanTryToCastSpell(pTarget, m_spells.druid.pAbolishPoison))
+                    {
+                        if (DoCastSpell(pTarget, m_spells.druid.pAbolishPoison) == SPELL_CAST_OK)
+                            return true;
+                    }
+                }
+            }
+            if (m_spells.druid.pRemoveCurse)
+            {
+                if (Player* pTarget = SelectDispelTarget(m_spells.druid.pRemoveCurse))
+                {
+                    if (CanTryToCastSpell(pTarget, m_spells.druid.pRemoveCurse))
+                    {
+                        if (DoCastSpell(pTarget, m_spells.druid.pRemoveCurse) == SPELL_CAST_OK)
+                            return true;
+                    }
+                }
+            }
+            break;
+    }
+
+    return false;
+}
+
+uint32 PartyBotAI::CountPlayersNeedingBuff(SpellEntry const* pSpellEntry) const
+{
+    if (!pSpellEntry)
+        return 0;
+
+    uint32 count = 0;
+    Group* pGroup = me->GetGroup();
+    if (pGroup)
+    {
+        for (GroupReference* itr = pGroup->GetFirstMember(); itr != nullptr; itr = itr->next())
+        {
+            if (Player* pMember = itr->getSource())
+            {
+                if (me->IsValidHelpfulTarget(pMember) &&
+                   !pMember->IsGameMaster() &&
+                    IsValidBuffTarget(pMember, pSpellEntry) &&
+                    me->IsWithinLOSInMap(pMember) &&
+                    me->IsWithinDist(pMember, 30.0f))
+                {
+                    count++;
+                }
+            }
+        }
+    }
+    return count;
+}
+
+bool PartyBotAI::NeedsToBuffAlly() const
+{
+    if (IsInDuel())
+        return false;
+
+    // Check if bot has any buff spells that are needed
+    switch (me->GetClass())
+    {
+        case CLASS_PALADIN:
+            if (m_spells.paladin.pBlessingBuff)
+            {
+                if (Player* pTarget = SelectBuffTarget(m_spells.paladin.pBlessingBuff))
+                {
+                    if (CanTryToCastSpell(pTarget, m_spells.paladin.pBlessingBuff))
+                        return true;
+                }
+            }
+            break;
+        case CLASS_MAGE:
+            if (m_spells.mage.pArcaneIntellect)
+            {
+                if (Player* pTarget = SelectBuffTarget(m_spells.mage.pArcaneIntellect))
+                {
+                    if (CanTryToCastSpell(pTarget, m_spells.mage.pArcaneIntellect))
+                        return true;
+                }
+            }
+            break;
+        case CLASS_PRIEST:
+            // Check Fortitude buffs (prefer single target if only 1 player needs it)
+            if (m_spells.priest.pPowerWordFortitude)
+            {
+                uint32 fortitudeCount = CountPlayersNeedingBuff(m_spells.priest.pPowerWordFortitude);
+                if (fortitudeCount > 0)
+                {
+                    // Use group buff if 2+ players need it and we have it
+                    if (fortitudeCount >= 2 && m_spells.priest.pPrayerofFortitude)
+                    {
+                        if (Player* pTarget = SelectBuffTarget(m_spells.priest.pPrayerofFortitude))
+                        {
+                            if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofFortitude))
+                                return true;
+                        }
+                    }
+                    // Use single target if only 1 player needs it or no group buff
+                    if (Player* pTarget = SelectBuffTarget(m_spells.priest.pPowerWordFortitude))
+                    {
+                        if (CanTryToCastSpell(pTarget, m_spells.priest.pPowerWordFortitude))
+                            return true;
+                    }
+                }
+            }
+            // Check Spirit buffs (prefer single target if only 1 player needs it)
+            if (m_spells.priest.pDivineSpirit)
+            {
+                uint32 spiritCount = CountPlayersNeedingBuff(m_spells.priest.pDivineSpirit);
+                if (spiritCount > 0)
+                {
+                    // Use group buff if 2+ players need it and we have it
+                    if (spiritCount >= 2 && m_spells.priest.pPrayerofSpirit)
+                    {
+                        if (Player* pTarget = SelectBuffTarget(m_spells.priest.pPrayerofSpirit))
+                        {
+                            if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofSpirit))
+                                return true;
+                        }
+                    }
+                    // Use single target if only 1 player needs it or no group buff
+                    if (Player* pTarget = SelectBuffTarget(m_spells.priest.pDivineSpirit))
+                    {
+                        if (CanTryToCastSpell(pTarget, m_spells.priest.pDivineSpirit))
+                            return true;
+                    }
+                }
+            }
+            // Check Shadow Protection buffs (prefer single target if only 1 player needs it)
+            if (m_spells.priest.pShadowProtection)
+            {
+                uint32 shadowProtCount = CountPlayersNeedingBuff(m_spells.priest.pShadowProtection);
+                if (shadowProtCount > 0)
+                {
+                    // Use group buff if 2+ players need it and we have it
+                    if (shadowProtCount >= 2 && m_spells.priest.pPrayerofShadowProtection)
+                    {
+                        if (Player* pTarget = SelectBuffTarget(m_spells.priest.pPrayerofShadowProtection))
+                        {
+                            if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofShadowProtection))
+                                return true;
+                        }
+                    }
+                    // Use single target if only 1 player needs it or no group buff
+                    if (Player* pTarget = SelectBuffTarget(m_spells.priest.pShadowProtection))
+                    {
+                        if (CanTryToCastSpell(pTarget, m_spells.priest.pShadowProtection))
+                            return true;
+                    }
+                }
+            }
+            break;
+        case CLASS_WARLOCK:
+            if (m_spells.warlock.pDetectInvisibility)
+            {
+                if (Player* pTarget = SelectBuffTarget(m_spells.warlock.pDetectInvisibility))
+                {
+                    if (CanTryToCastSpell(pTarget, m_spells.warlock.pDetectInvisibility))
+                        return true;
+                }
+            }
+            break;
+        case CLASS_DRUID:
+            // Check Mark of the Wild buffs (prefer single target if only 1 player needs it)
+            if (m_spells.druid.pMarkoftheWild)
+            {
+                uint32 motWCount = CountPlayersNeedingBuff(m_spells.druid.pMarkoftheWild);
+                if (motWCount > 0)
+                {
+                    // Use group buff if 2+ players need it and we have it
+                    if (motWCount >= 2 && m_spells.druid.pGiftoftheWild)
+                    {
+                        if (Player* pTarget = SelectBuffTarget(m_spells.druid.pGiftoftheWild))
+                        {
+                            if (CanTryToCastSpell(pTarget, m_spells.druid.pGiftoftheWild))
+                                return true;
+                        }
+                    }
+                    // Use single target if only 1 player needs it or no group buff
+                    if (Player* pTarget = SelectBuffTarget(m_spells.druid.pMarkoftheWild))
+                    {
+                        if (CanTryToCastSpell(pTarget, m_spells.druid.pMarkoftheWild))
+                            return true;
+                    }
+                }
+            }
+            if (m_spells.druid.pThorns)
+            {
+                if (Player* pTarget = SelectBuffTarget(m_spells.druid.pThorns))
+                {
+                    if (CanTryToCastSpell(pTarget, m_spells.druid.pThorns))
+                        return true;
+                }
+            }
+            break;
+    }
+
+    return false;
+}
+
+bool PartyBotAI::TryBuffAlly()
+{
+    if (IsInDuel())
+        return false;
+
+    // Try each class's buff spells
+    switch (me->GetClass())
+    {
+        case CLASS_PALADIN:
+            if (m_spells.paladin.pBlessingBuff)
+            {
+                if (Player* pTarget = SelectBuffTarget(m_spells.paladin.pBlessingBuff))
+                {
+                    if (CanTryToCastSpell(pTarget, m_spells.paladin.pBlessingBuff))
+                    {
+                        if (DoCastSpell(pTarget, m_spells.paladin.pBlessingBuff) == SPELL_CAST_OK)
+                        {
+                            m_isBuffing = true;
+                            me->ClearTarget();
+                            return true;
+                        }
+                    }
+                }
+            }
+            break;
+        case CLASS_MAGE:
+            if (m_spells.mage.pArcaneIntellect)
+            {
+                if (Player* pTarget = SelectBuffTarget(m_spells.mage.pArcaneIntellect))
+                {
+                    if (CanTryToCastSpell(pTarget, m_spells.mage.pArcaneIntellect))
+                    {
+                        if (DoCastSpell(pTarget, m_spells.mage.pArcaneIntellect) == SPELL_CAST_OK)
+                        {
+                            m_isBuffing = true;
+                            me->ClearTarget();
+                            return true;
+                        }
+                    }
+                }
+            }
+            break;
+        case CLASS_PRIEST:
+            // Check Fortitude buffs (prefer single target if only 1 player needs it)
+            if (m_spells.priest.pPowerWordFortitude)
+            {
+                uint32 fortitudeCount = CountPlayersNeedingBuff(m_spells.priest.pPowerWordFortitude);
+                if (fortitudeCount > 0)
+                {
+                    // Use group buff if 2+ players need it and we have it
+                    if (fortitudeCount >= 2 && m_spells.priest.pPrayerofFortitude)
+                    {
+                        if (Player* pTarget = SelectBuffTarget(m_spells.priest.pPrayerofFortitude))
+                        {
+                            if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofFortitude))
+                            {
+                                if (DoCastSpell(pTarget, m_spells.priest.pPrayerofFortitude) == SPELL_CAST_OK)
+                                {
+                                    m_isBuffing = true;
+                                    me->ClearTarget();
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+                    // Use single target if only 1 player needs it or no group buff
+                    if (Player* pTarget = SelectBuffTarget(m_spells.priest.pPowerWordFortitude))
+                    {
+                        if (CanTryToCastSpell(pTarget, m_spells.priest.pPowerWordFortitude))
+                        {
+                            if (DoCastSpell(pTarget, m_spells.priest.pPowerWordFortitude) == SPELL_CAST_OK)
+                            {
+                                m_isBuffing = true;
+                                me->ClearTarget();
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+            // Check Spirit buffs (prefer single target if only 1 player needs it)
+            if (m_spells.priest.pDivineSpirit)
+            {
+                uint32 spiritCount = CountPlayersNeedingBuff(m_spells.priest.pDivineSpirit);
+                if (spiritCount > 0)
+                {
+                    // Use group buff if 2+ players need it and we have it
+                    if (spiritCount >= 2 && m_spells.priest.pPrayerofSpirit)
+                    {
+                        if (Player* pTarget = SelectBuffTarget(m_spells.priest.pPrayerofSpirit))
+                        {
+                            if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofSpirit))
+                            {
+                                if (DoCastSpell(pTarget, m_spells.priest.pPrayerofSpirit) == SPELL_CAST_OK)
+                                {
+                                    m_isBuffing = true;
+                                    me->ClearTarget();
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+                    // Use single target if only 1 player needs it or no group buff
+                    if (Player* pTarget = SelectBuffTarget(m_spells.priest.pDivineSpirit))
+                    {
+                        if (CanTryToCastSpell(pTarget, m_spells.priest.pDivineSpirit))
+                        {
+                            if (DoCastSpell(pTarget, m_spells.priest.pDivineSpirit) == SPELL_CAST_OK)
+                            {
+                                m_isBuffing = true;
+                                me->ClearTarget();
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+            // Check Shadow Protection buffs (prefer single target if only 1 player needs it)
+            if (m_spells.priest.pShadowProtection)
+            {
+                uint32 shadowProtCount = CountPlayersNeedingBuff(m_spells.priest.pShadowProtection);
+                if (shadowProtCount > 0)
+                {
+                    // Use group buff if 2+ players need it and we have it
+                    if (shadowProtCount >= 2 && m_spells.priest.pPrayerofShadowProtection)
+                    {
+                        if (Player* pTarget = SelectBuffTarget(m_spells.priest.pPrayerofShadowProtection))
+                        {
+                            if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofShadowProtection))
+                            {
+                                if (DoCastSpell(pTarget, m_spells.priest.pPrayerofShadowProtection) == SPELL_CAST_OK)
+                                {
+                                    m_isBuffing = true;
+                                    me->ClearTarget();
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+                    // Use single target if only 1 player needs it or no group buff
+                    if (Player* pTarget = SelectBuffTarget(m_spells.priest.pShadowProtection))
+                    {
+                        if (CanTryToCastSpell(pTarget, m_spells.priest.pShadowProtection))
+                        {
+                            if (DoCastSpell(pTarget, m_spells.priest.pShadowProtection) == SPELL_CAST_OK)
+                            {
+                                m_isBuffing = true;
+                                me->ClearTarget();
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+            break;
+        case CLASS_WARLOCK:
+            if (m_spells.warlock.pDetectInvisibility)
+            {
+                if (Player* pTarget = SelectBuffTarget(m_spells.warlock.pDetectInvisibility))
+                {
+                    if (CanTryToCastSpell(pTarget, m_spells.warlock.pDetectInvisibility))
+                    {
+                        if (DoCastSpell(pTarget, m_spells.warlock.pDetectInvisibility) == SPELL_CAST_OK)
+                        {
+                            m_isBuffing = true;
+                            me->ClearTarget();
+                            return true;
+                        }
+                    }
+                }
+            }
+            break;
+        case CLASS_DRUID:
+            // Check Mark of the Wild buffs (prefer single target if only 1 player needs it)
+            if (m_spells.druid.pMarkoftheWild)
+            {
+                uint32 motWCount = CountPlayersNeedingBuff(m_spells.druid.pMarkoftheWild);
+                if (motWCount > 0)
+                {
+                    // Use group buff if 2+ players need it and we have it
+                    if (motWCount >= 2 && m_spells.druid.pGiftoftheWild)
+                    {
+                        if (Player* pTarget = SelectBuffTarget(m_spells.druid.pGiftoftheWild))
+                        {
+                            if (CanTryToCastSpell(pTarget, m_spells.druid.pGiftoftheWild))
+                            {
+                                if (DoCastSpell(pTarget, m_spells.druid.pGiftoftheWild) == SPELL_CAST_OK)
+                                {
+                                    m_isBuffing = true;
+                                    me->ClearTarget();
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+                    // Use single target if only 1 player needs it or no group buff
+                    if (Player* pTarget = SelectBuffTarget(m_spells.druid.pMarkoftheWild))
+                    {
+                        if (CanTryToCastSpell(pTarget, m_spells.druid.pMarkoftheWild))
+                        {
+                            if (DoCastSpell(pTarget, m_spells.druid.pMarkoftheWild) == SPELL_CAST_OK)
+                            {
+                                m_isBuffing = true;
+                                me->ClearTarget();
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+            if (m_spells.druid.pThorns)
+            {
+                if (Player* pTarget = SelectBuffTarget(m_spells.druid.pThorns))
+                {
+                    if (CanTryToCastSpell(pTarget, m_spells.druid.pThorns))
+                    {
+                        if (DoCastSpell(pTarget, m_spells.druid.pThorns) == SPELL_CAST_OK)
+                        {
+                            m_isBuffing = true;
+                            me->ClearTarget();
+                            return true;
+                        }
+                    }
+                }
+            }
+            break;
+    }
+
+    return false;
 }
 
 Player* PartyBotAI::SelectShieldTarget() const
@@ -932,6 +1522,40 @@ void PartyBotAI::UpdateAI(uint32 const diff)
                         return;
                 }
             }
+        }
+
+        // All bots should prioritize dispelling over drinking
+        if (NeedsToDispelAlly())
+        {
+            // Stop drinking/eating to cast dispel
+            if (me->HasAura(PB_SPELL_DRINK))
+                me->RemoveAurasDueToSpell(PB_SPELL_DRINK);
+            if (me->HasAura(PB_SPELL_FOOD))
+                me->RemoveAurasDueToSpell(PB_SPELL_FOOD);
+            
+            // Stand up if sitting
+            if (me->GetStandState() != UNIT_STAND_STATE_STAND)
+                me->SetStandState(UNIT_STAND_STATE_STAND);
+            
+            if (TryDispelAlly())
+                return;
+        }
+
+        // All bots should prioritize buffing over drinking
+        if (NeedsToBuffAlly())
+        {
+            // Stop drinking/eating to cast buff
+            if (me->HasAura(PB_SPELL_DRINK))
+                me->RemoveAurasDueToSpell(PB_SPELL_DRINK);
+            if (me->HasAura(PB_SPELL_FOOD))
+                me->RemoveAurasDueToSpell(PB_SPELL_FOOD);
+            
+            // Stand up if sitting
+            if (me->GetStandState() != UNIT_STAND_STATE_STAND)
+                me->SetStandState(UNIT_STAND_STATE_STAND);
+            
+            if (TryBuffAlly())
+                return;
         }
 
         if (DrinkAndEat())

--- a/src/game/PlayerBots/PartyBotAI.h
+++ b/src/game/PlayerBots/PartyBotAI.h
@@ -73,6 +73,11 @@ public:
     Unit* SelectPartyAttackTarget() const;
     Player* SelectResurrectionTarget() const;
     Player* SelectShieldTarget() const;
+    bool NeedsToDispelAlly() const;
+    bool TryDispelAlly();
+    bool NeedsToBuffAlly() const;
+    bool TryBuffAlly();
+    uint32 CountPlayersNeedingBuff(SpellEntry const* pSpellEntry) const;
     Unit* GetMarkedTarget(RaidTargetIcon mark) const;
     bool CanUseCrowdControl(SpellEntry const* pSpellEntry, Unit* pTarget) const;
     bool DrinkAndEat();


### PR DESCRIPTION
#### 1. Resurrection Priority (Healers)
- Healers now check for dead allies before drinking
- Will stop drinking immediately to resurrect if they have sufficient mana
- Won't start drinking if resurrection is needed and mana is available

<br>

#### 2. Dispel Priority (All Classes)
- All classes with dispel abilities now prioritize dispelling over drinking
- Will interrupt drinking to dispel debuffs when mana is available
- Supports:
  - **Paladin** (_Cleanse_)
  - **Priest** (_Dispel Magic, Abolish Disease_)
  - **Shaman** (_Cure Disease/Poison_)
  - **Mage** (_Remove Lesser Curse_)
  - **Druid** (_Abolish Poison, Remove Curse_)

<br>

#### 3. Buff Priority (All Classes)
- All classes with buffs now prioritize buffing over drinking
- Bots buff as soon as they have sufficient mana instead of waiting for full mana
- Supports:
  - **Paladin** (_Blessings_)
  - **Priest** (_Fortitude, Spirit, Shadow Protection_)
  - **Druid** (_Mark/Gift of the Wild, Thorns_)
  - **Mage** (_Arcane Intellect_)
  - **Warlock** (_Detect Invisibility_)
 
<br>

#### 4. Smart Buff Selection
- Bots will choose between single-target and group buffs based on need
- Will use group buffs when 2+ players need buffed
- Will use single-target buffs when only 1 player needs buffed