### PR TITLE
PartyBotAI: Fixed group/single-target buffing strategy

### DIFF
--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -41,6 +41,21 @@ enum PartyBotSpells
     PB_SPELL_HONORLESS_TARGET = 2479,
 };
 
+namespace
+{
+// Group buff is preferred for this line but we cannot pay its cost yet — skip single-target so we can regen/drink.
+bool InsufficientPowerForBuffSpell(Player* caster, SpellEntry const* pSpellEntry)
+{
+    if (!caster || !pSpellEntry)
+        return false;
+    uint32 const powerCost = Spell::CalculatePowerCost(pSpellEntry, caster);
+    Powers const powerType = Powers(pSpellEntry->powerType);
+    if (powerType == POWER_HEALTH)
+        return caster->GetHealth() <= powerCost;
+    return caster->GetPower(powerType) < powerCost;
+}
+}
+
 bool PartyBotAI::OnSessionLoaded(PlayerBotEntry* entry, WorldSession* sess)
 {
     if (!m_race && !m_class)
@@ -764,6 +779,63 @@ uint32 PartyBotAI::CountPlayersNeedingBuff(SpellEntry const* pSpellEntry) const
     return count;
 }
 
+bool PartyBotAI::TargetLacksBuffLine(Unit const* pTarget, SpellEntry const* pSingleTargetSpell, SpellEntry const* pGroupBuffSpell) const
+{
+    if (!pSingleTargetSpell && !pGroupBuffSpell)
+        return false;
+    bool const lacksSingle = !pSingleTargetSpell || IsValidBuffTarget(pTarget, pSingleTargetSpell);
+    bool const lacksGroup = !pGroupBuffSpell || IsValidBuffTarget(pTarget, pGroupBuffSpell);
+    return lacksSingle && lacksGroup;
+}
+
+uint32 PartyBotAI::CountPlayersNeedingBuffLine(SpellEntry const* pSingleTargetSpell, SpellEntry const* pGroupBuffSpell) const
+{
+    if (!pSingleTargetSpell && !pGroupBuffSpell)
+        return 0;
+
+    uint32 count = 0;
+    Group* pGroup = me->GetGroup();
+    if (pGroup)
+    {
+        for (GroupReference* itr = pGroup->GetFirstMember(); itr != nullptr; itr = itr->next())
+        {
+            if (Player* pMember = itr->getSource())
+            {
+                if (me->IsValidHelpfulTarget(pMember) &&
+                   !pMember->IsGameMaster() &&
+                    TargetLacksBuffLine(pMember, pSingleTargetSpell, pGroupBuffSpell) &&
+                    me->IsWithinLOSInMap(pMember) &&
+                    me->IsWithinDist(pMember, 30.0f))
+                {
+                    ++count;
+                }
+            }
+        }
+    }
+    return count;
+}
+
+Player* PartyBotAI::SelectBuffTargetForBuffLine(SpellEntry const* pSingleTargetSpell, SpellEntry const* pGroupBuffSpell) const
+{
+    Group* pGroup = me->GetGroup();
+    if (pGroup)
+    {
+        for (GroupReference* itr = pGroup->GetFirstMember(); itr != nullptr; itr = itr->next())
+        {
+            if (Player* pMember = itr->getSource())
+            {
+                if (me->IsValidHelpfulTarget(pMember) &&
+                   !pMember->IsGameMaster() &&
+                    TargetLacksBuffLine(pMember, pSingleTargetSpell, pGroupBuffSpell) &&
+                    me->IsWithinLOSInMap(pMember) &&
+                    me->IsWithinDist(pMember, 30.0f))
+                    return pMember;
+            }
+        }
+    }
+    return nullptr;
+}
+
 bool PartyBotAI::NeedsToBuffAlly() const
 {
     if (IsInDuel())
@@ -794,71 +866,107 @@ bool PartyBotAI::NeedsToBuffAlly() const
             break;
         case CLASS_PRIEST:
             // Check Fortitude buffs (prefer single target if only 1 player needs it)
-            if (m_spells.priest.pPowerWordFortitude)
+            if (m_spells.priest.pPowerWordFortitude || m_spells.priest.pPrayerofFortitude)
             {
-                uint32 fortitudeCount = CountPlayersNeedingBuff(m_spells.priest.pPowerWordFortitude);
+                uint32 fortitudeCount = CountPlayersNeedingBuffLine(m_spells.priest.pPowerWordFortitude, m_spells.priest.pPrayerofFortitude);
                 if (fortitudeCount > 0)
                 {
-                    // Use group buff if 2+ players need it and we have it
+                    bool skipFortitudeSingle = false;
                     if (fortitudeCount >= 2 && m_spells.priest.pPrayerofFortitude)
                     {
-                        if (Player* pTarget = SelectBuffTarget(m_spells.priest.pPrayerofFortitude))
+                        if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pPowerWordFortitude, m_spells.priest.pPrayerofFortitude))
+                        {
+                            if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofFortitude))
+                                return true;
+                            if (InsufficientPowerForBuffSpell(me, m_spells.priest.pPrayerofFortitude))
+                                skipFortitudeSingle = true;
+                        }
+                    }
+                    if (!skipFortitudeSingle && m_spells.priest.pPowerWordFortitude)
+                    {
+                        if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pPowerWordFortitude, m_spells.priest.pPrayerofFortitude))
+                        {
+                            if (CanTryToCastSpell(pTarget, m_spells.priest.pPowerWordFortitude))
+                                return true;
+                        }
+                    }
+                    else if (!skipFortitudeSingle && m_spells.priest.pPrayerofFortitude && !m_spells.priest.pPowerWordFortitude)
+                    {
+                        if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pPowerWordFortitude, m_spells.priest.pPrayerofFortitude))
                         {
                             if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofFortitude))
                                 return true;
                         }
                     }
-                    // Use single target if only 1 player needs it or no group buff
-                    if (Player* pTarget = SelectBuffTarget(m_spells.priest.pPowerWordFortitude))
-                    {
-                        if (CanTryToCastSpell(pTarget, m_spells.priest.pPowerWordFortitude))
-                            return true;
-                    }
                 }
             }
             // Check Spirit buffs (prefer single target if only 1 player needs it)
-            if (m_spells.priest.pDivineSpirit)
+            if (m_spells.priest.pDivineSpirit || m_spells.priest.pPrayerofSpirit)
             {
-                uint32 spiritCount = CountPlayersNeedingBuff(m_spells.priest.pDivineSpirit);
+                uint32 spiritCount = CountPlayersNeedingBuffLine(m_spells.priest.pDivineSpirit, m_spells.priest.pPrayerofSpirit);
                 if (spiritCount > 0)
                 {
-                    // Use group buff if 2+ players need it and we have it
+                    bool skipSpiritSingle = false;
                     if (spiritCount >= 2 && m_spells.priest.pPrayerofSpirit)
                     {
-                        if (Player* pTarget = SelectBuffTarget(m_spells.priest.pPrayerofSpirit))
+                        if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pDivineSpirit, m_spells.priest.pPrayerofSpirit))
+                        {
+                            if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofSpirit))
+                                return true;
+                            if (InsufficientPowerForBuffSpell(me, m_spells.priest.pPrayerofSpirit))
+                                skipSpiritSingle = true;
+                        }
+                    }
+                    if (!skipSpiritSingle && m_spells.priest.pDivineSpirit)
+                    {
+                        if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pDivineSpirit, m_spells.priest.pPrayerofSpirit))
+                        {
+                            if (CanTryToCastSpell(pTarget, m_spells.priest.pDivineSpirit))
+                                return true;
+                        }
+                    }
+                    else if (!skipSpiritSingle && m_spells.priest.pPrayerofSpirit && !m_spells.priest.pDivineSpirit)
+                    {
+                        if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pDivineSpirit, m_spells.priest.pPrayerofSpirit))
                         {
                             if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofSpirit))
                                 return true;
                         }
                     }
-                    // Use single target if only 1 player needs it or no group buff
-                    if (Player* pTarget = SelectBuffTarget(m_spells.priest.pDivineSpirit))
-                    {
-                        if (CanTryToCastSpell(pTarget, m_spells.priest.pDivineSpirit))
-                            return true;
-                    }
                 }
             }
             // Check Shadow Protection buffs (prefer single target if only 1 player needs it)
-            if (m_spells.priest.pShadowProtection)
+            if (m_spells.priest.pShadowProtection || m_spells.priest.pPrayerofShadowProtection)
             {
-                uint32 shadowProtCount = CountPlayersNeedingBuff(m_spells.priest.pShadowProtection);
+                uint32 shadowProtCount = CountPlayersNeedingBuffLine(m_spells.priest.pShadowProtection, m_spells.priest.pPrayerofShadowProtection);
                 if (shadowProtCount > 0)
                 {
-                    // Use group buff if 2+ players need it and we have it
+                    bool skipShadowProtSingle = false;
                     if (shadowProtCount >= 2 && m_spells.priest.pPrayerofShadowProtection)
                     {
-                        if (Player* pTarget = SelectBuffTarget(m_spells.priest.pPrayerofShadowProtection))
+                        if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pShadowProtection, m_spells.priest.pPrayerofShadowProtection))
+                        {
+                            if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofShadowProtection))
+                                return true;
+                            if (InsufficientPowerForBuffSpell(me, m_spells.priest.pPrayerofShadowProtection))
+                                skipShadowProtSingle = true;
+                        }
+                    }
+                    if (!skipShadowProtSingle && m_spells.priest.pShadowProtection)
+                    {
+                        if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pShadowProtection, m_spells.priest.pPrayerofShadowProtection))
+                        {
+                            if (CanTryToCastSpell(pTarget, m_spells.priest.pShadowProtection))
+                                return true;
+                        }
+                    }
+                    else if (!skipShadowProtSingle && m_spells.priest.pPrayerofShadowProtection && !m_spells.priest.pShadowProtection)
+                    {
+                        if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pShadowProtection, m_spells.priest.pPrayerofShadowProtection))
                         {
                             if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofShadowProtection))
                                 return true;
                         }
-                    }
-                    // Use single target if only 1 player needs it or no group buff
-                    if (Player* pTarget = SelectBuffTarget(m_spells.priest.pShadowProtection))
-                    {
-                        if (CanTryToCastSpell(pTarget, m_spells.priest.pShadowProtection))
-                            return true;
                     }
                 }
             }
@@ -875,25 +983,37 @@ bool PartyBotAI::NeedsToBuffAlly() const
             break;
         case CLASS_DRUID:
             // Check Mark of the Wild buffs (prefer single target if only 1 player needs it)
-            if (m_spells.druid.pMarkoftheWild)
+            if (m_spells.druid.pMarkoftheWild || m_spells.druid.pGiftoftheWild)
             {
-                uint32 motWCount = CountPlayersNeedingBuff(m_spells.druid.pMarkoftheWild);
+                uint32 motWCount = CountPlayersNeedingBuffLine(m_spells.druid.pMarkoftheWild, m_spells.druid.pGiftoftheWild);
                 if (motWCount > 0)
                 {
-                    // Use group buff if 2+ players need it and we have it
+                    bool skipMotWSingle = false;
                     if (motWCount >= 2 && m_spells.druid.pGiftoftheWild)
                     {
-                        if (Player* pTarget = SelectBuffTarget(m_spells.druid.pGiftoftheWild))
+                        if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.druid.pMarkoftheWild, m_spells.druid.pGiftoftheWild))
+                        {
+                            if (CanTryToCastSpell(pTarget, m_spells.druid.pGiftoftheWild))
+                                return true;
+                            if (InsufficientPowerForBuffSpell(me, m_spells.druid.pGiftoftheWild))
+                                skipMotWSingle = true;
+                        }
+                    }
+                    if (!skipMotWSingle && m_spells.druid.pMarkoftheWild)
+                    {
+                        if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.druid.pMarkoftheWild, m_spells.druid.pGiftoftheWild))
+                        {
+                            if (CanTryToCastSpell(pTarget, m_spells.druid.pMarkoftheWild))
+                                return true;
+                        }
+                    }
+                    else if (!skipMotWSingle && m_spells.druid.pGiftoftheWild && !m_spells.druid.pMarkoftheWild)
+                    {
+                        if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.druid.pMarkoftheWild, m_spells.druid.pGiftoftheWild))
                         {
                             if (CanTryToCastSpell(pTarget, m_spells.druid.pGiftoftheWild))
                                 return true;
                         }
-                    }
-                    // Use single target if only 1 player needs it or no group buff
-                    if (Player* pTarget = SelectBuffTarget(m_spells.druid.pMarkoftheWild))
-                    {
-                        if (CanTryToCastSpell(pTarget, m_spells.druid.pMarkoftheWild))
-                            return true;
                     }
                 }
             }
@@ -955,15 +1075,47 @@ bool PartyBotAI::TryBuffAlly()
             break;
         case CLASS_PRIEST:
             // Check Fortitude buffs (prefer single target if only 1 player needs it)
-            if (m_spells.priest.pPowerWordFortitude)
+            if (m_spells.priest.pPowerWordFortitude || m_spells.priest.pPrayerofFortitude)
             {
-                uint32 fortitudeCount = CountPlayersNeedingBuff(m_spells.priest.pPowerWordFortitude);
+                uint32 fortitudeCount = CountPlayersNeedingBuffLine(m_spells.priest.pPowerWordFortitude, m_spells.priest.pPrayerofFortitude);
                 if (fortitudeCount > 0)
                 {
-                    // Use group buff if 2+ players need it and we have it
+                    bool skipFortitudeSingle = false;
                     if (fortitudeCount >= 2 && m_spells.priest.pPrayerofFortitude)
                     {
-                        if (Player* pTarget = SelectBuffTarget(m_spells.priest.pPrayerofFortitude))
+                        if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pPowerWordFortitude, m_spells.priest.pPrayerofFortitude))
+                        {
+                            if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofFortitude))
+                            {
+                                if (DoCastSpell(pTarget, m_spells.priest.pPrayerofFortitude) == SPELL_CAST_OK)
+                                {
+                                    m_isBuffing = true;
+                                    me->ClearTarget();
+                                    return true;
+                                }
+                            }
+                            else if (InsufficientPowerForBuffSpell(me, m_spells.priest.pPrayerofFortitude))
+                                skipFortitudeSingle = true;
+                        }
+                    }
+                    if (!skipFortitudeSingle && m_spells.priest.pPowerWordFortitude)
+                    {
+                        if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pPowerWordFortitude, m_spells.priest.pPrayerofFortitude))
+                        {
+                            if (CanTryToCastSpell(pTarget, m_spells.priest.pPowerWordFortitude))
+                            {
+                                if (DoCastSpell(pTarget, m_spells.priest.pPowerWordFortitude) == SPELL_CAST_OK)
+                                {
+                                    m_isBuffing = true;
+                                    me->ClearTarget();
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+                    else if (!skipFortitudeSingle && m_spells.priest.pPrayerofFortitude && !m_spells.priest.pPowerWordFortitude)
+                    {
+                        if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pPowerWordFortitude, m_spells.priest.pPrayerofFortitude))
                         {
                             if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofFortitude))
                             {
@@ -976,31 +1128,50 @@ bool PartyBotAI::TryBuffAlly()
                             }
                         }
                     }
-                    // Use single target if only 1 player needs it or no group buff
-                    if (Player* pTarget = SelectBuffTarget(m_spells.priest.pPowerWordFortitude))
-                    {
-                        if (CanTryToCastSpell(pTarget, m_spells.priest.pPowerWordFortitude))
-                        {
-                            if (DoCastSpell(pTarget, m_spells.priest.pPowerWordFortitude) == SPELL_CAST_OK)
-                            {
-                                m_isBuffing = true;
-                                me->ClearTarget();
-                                return true;
-                            }
-                        }
-                    }
                 }
             }
             // Check Spirit buffs (prefer single target if only 1 player needs it)
-            if (m_spells.priest.pDivineSpirit)
+            if (m_spells.priest.pDivineSpirit || m_spells.priest.pPrayerofSpirit)
             {
-                uint32 spiritCount = CountPlayersNeedingBuff(m_spells.priest.pDivineSpirit);
+                uint32 spiritCount = CountPlayersNeedingBuffLine(m_spells.priest.pDivineSpirit, m_spells.priest.pPrayerofSpirit);
                 if (spiritCount > 0)
                 {
-                    // Use group buff if 2+ players need it and we have it
+                    bool skipSpiritSingle = false;
                     if (spiritCount >= 2 && m_spells.priest.pPrayerofSpirit)
                     {
-                        if (Player* pTarget = SelectBuffTarget(m_spells.priest.pPrayerofSpirit))
+                        if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pDivineSpirit, m_spells.priest.pPrayerofSpirit))
+                        {
+                            if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofSpirit))
+                            {
+                                if (DoCastSpell(pTarget, m_spells.priest.pPrayerofSpirit) == SPELL_CAST_OK)
+                                {
+                                    m_isBuffing = true;
+                                    me->ClearTarget();
+                                    return true;
+                                }
+                            }
+                            else if (InsufficientPowerForBuffSpell(me, m_spells.priest.pPrayerofSpirit))
+                                skipSpiritSingle = true;
+                        }
+                    }
+                    if (!skipSpiritSingle && m_spells.priest.pDivineSpirit)
+                    {
+                        if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pDivineSpirit, m_spells.priest.pPrayerofSpirit))
+                        {
+                            if (CanTryToCastSpell(pTarget, m_spells.priest.pDivineSpirit))
+                            {
+                                if (DoCastSpell(pTarget, m_spells.priest.pDivineSpirit) == SPELL_CAST_OK)
+                                {
+                                    m_isBuffing = true;
+                                    me->ClearTarget();
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+                    else if (!skipSpiritSingle && m_spells.priest.pPrayerofSpirit && !m_spells.priest.pDivineSpirit)
+                    {
+                        if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pDivineSpirit, m_spells.priest.pPrayerofSpirit))
                         {
                             if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofSpirit))
                             {
@@ -1013,31 +1184,18 @@ bool PartyBotAI::TryBuffAlly()
                             }
                         }
                     }
-                    // Use single target if only 1 player needs it or no group buff
-                    if (Player* pTarget = SelectBuffTarget(m_spells.priest.pDivineSpirit))
-                    {
-                        if (CanTryToCastSpell(pTarget, m_spells.priest.pDivineSpirit))
-                        {
-                            if (DoCastSpell(pTarget, m_spells.priest.pDivineSpirit) == SPELL_CAST_OK)
-                            {
-                                m_isBuffing = true;
-                                me->ClearTarget();
-                                return true;
-                            }
-                        }
-                    }
                 }
             }
             // Check Shadow Protection buffs (prefer single target if only 1 player needs it)
-            if (m_spells.priest.pShadowProtection)
+            if (m_spells.priest.pShadowProtection || m_spells.priest.pPrayerofShadowProtection)
             {
-                uint32 shadowProtCount = CountPlayersNeedingBuff(m_spells.priest.pShadowProtection);
+                uint32 shadowProtCount = CountPlayersNeedingBuffLine(m_spells.priest.pShadowProtection, m_spells.priest.pPrayerofShadowProtection);
                 if (shadowProtCount > 0)
                 {
-                    // Use group buff if 2+ players need it and we have it
+                    bool skipShadowProtSingle = false;
                     if (shadowProtCount >= 2 && m_spells.priest.pPrayerofShadowProtection)
                     {
-                        if (Player* pTarget = SelectBuffTarget(m_spells.priest.pPrayerofShadowProtection))
+                        if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pShadowProtection, m_spells.priest.pPrayerofShadowProtection))
                         {
                             if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofShadowProtection))
                             {
@@ -1048,18 +1206,37 @@ bool PartyBotAI::TryBuffAlly()
                                     return true;
                                 }
                             }
+                            else if (InsufficientPowerForBuffSpell(me, m_spells.priest.pPrayerofShadowProtection))
+                                skipShadowProtSingle = true;
                         }
                     }
-                    // Use single target if only 1 player needs it or no group buff
-                    if (Player* pTarget = SelectBuffTarget(m_spells.priest.pShadowProtection))
+                    if (!skipShadowProtSingle && m_spells.priest.pShadowProtection)
                     {
-                        if (CanTryToCastSpell(pTarget, m_spells.priest.pShadowProtection))
+                        if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pShadowProtection, m_spells.priest.pPrayerofShadowProtection))
                         {
-                            if (DoCastSpell(pTarget, m_spells.priest.pShadowProtection) == SPELL_CAST_OK)
+                            if (CanTryToCastSpell(pTarget, m_spells.priest.pShadowProtection))
                             {
-                                m_isBuffing = true;
-                                me->ClearTarget();
-                                return true;
+                                if (DoCastSpell(pTarget, m_spells.priest.pShadowProtection) == SPELL_CAST_OK)
+                                {
+                                    m_isBuffing = true;
+                                    me->ClearTarget();
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+                    else if (!skipShadowProtSingle && m_spells.priest.pPrayerofShadowProtection && !m_spells.priest.pShadowProtection)
+                    {
+                        if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pShadowProtection, m_spells.priest.pPrayerofShadowProtection))
+                        {
+                            if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofShadowProtection))
+                            {
+                                if (DoCastSpell(pTarget, m_spells.priest.pPrayerofShadowProtection) == SPELL_CAST_OK)
+                                {
+                                    m_isBuffing = true;
+                                    me->ClearTarget();
+                                    return true;
+                                }
                             }
                         }
                     }
@@ -1085,15 +1262,15 @@ bool PartyBotAI::TryBuffAlly()
             break;
         case CLASS_DRUID:
             // Check Mark of the Wild buffs (prefer single target if only 1 player needs it)
-            if (m_spells.druid.pMarkoftheWild)
+            if (m_spells.druid.pMarkoftheWild || m_spells.druid.pGiftoftheWild)
             {
-                uint32 motWCount = CountPlayersNeedingBuff(m_spells.druid.pMarkoftheWild);
+                uint32 motWCount = CountPlayersNeedingBuffLine(m_spells.druid.pMarkoftheWild, m_spells.druid.pGiftoftheWild);
                 if (motWCount > 0)
                 {
-                    // Use group buff if 2+ players need it and we have it
+                    bool skipMotWSingle = false;
                     if (motWCount >= 2 && m_spells.druid.pGiftoftheWild)
                     {
-                        if (Player* pTarget = SelectBuffTarget(m_spells.druid.pGiftoftheWild))
+                        if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.druid.pMarkoftheWild, m_spells.druid.pGiftoftheWild))
                         {
                             if (CanTryToCastSpell(pTarget, m_spells.druid.pGiftoftheWild))
                             {
@@ -1104,18 +1281,37 @@ bool PartyBotAI::TryBuffAlly()
                                     return true;
                                 }
                             }
+                            else if (InsufficientPowerForBuffSpell(me, m_spells.druid.pGiftoftheWild))
+                                skipMotWSingle = true;
                         }
                     }
-                    // Use single target if only 1 player needs it or no group buff
-                    if (Player* pTarget = SelectBuffTarget(m_spells.druid.pMarkoftheWild))
+                    if (!skipMotWSingle && m_spells.druid.pMarkoftheWild)
                     {
-                        if (CanTryToCastSpell(pTarget, m_spells.druid.pMarkoftheWild))
+                        if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.druid.pMarkoftheWild, m_spells.druid.pGiftoftheWild))
                         {
-                            if (DoCastSpell(pTarget, m_spells.druid.pMarkoftheWild) == SPELL_CAST_OK)
+                            if (CanTryToCastSpell(pTarget, m_spells.druid.pMarkoftheWild))
                             {
-                                m_isBuffing = true;
-                                me->ClearTarget();
-                                return true;
+                                if (DoCastSpell(pTarget, m_spells.druid.pMarkoftheWild) == SPELL_CAST_OK)
+                                {
+                                    m_isBuffing = true;
+                                    me->ClearTarget();
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+                    else if (!skipMotWSingle && m_spells.druid.pGiftoftheWild && !m_spells.druid.pMarkoftheWild)
+                    {
+                        if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.druid.pMarkoftheWild, m_spells.druid.pGiftoftheWild))
+                        {
+                            if (CanTryToCastSpell(pTarget, m_spells.druid.pGiftoftheWild))
+                            {
+                                if (DoCastSpell(pTarget, m_spells.druid.pGiftoftheWild) == SPELL_CAST_OK)
+                                {
+                                    m_isBuffing = true;
+                                    me->ClearTarget();
+                                    return true;
+                                }
                             }
                         }
                     }
@@ -2785,95 +2981,169 @@ void PartyBotAI::UpdateOutOfCombatAI_Priest()
         }
     }
 
-    if (m_spells.priest.pPrayerofFortitude)
+    if (m_spells.priest.pPowerWordFortitude || m_spells.priest.pPrayerofFortitude)
     {
-        if (Player* pTarget = SelectBuffTarget(m_spells.priest.pPrayerofFortitude))
+        uint32 fortNeed = CountPlayersNeedingBuffLine(m_spells.priest.pPowerWordFortitude, m_spells.priest.pPrayerofFortitude);
+        if (fortNeed > 0)
         {
-            if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofFortitude))
+            bool skipFortitudeSingle = false;
+            if (fortNeed >= 2 && m_spells.priest.pPrayerofFortitude)
             {
-                if (DoCastSpell(pTarget, m_spells.priest.pPrayerofFortitude) == SPELL_CAST_OK)
+                if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pPowerWordFortitude, m_spells.priest.pPrayerofFortitude))
                 {
-                    m_isBuffing = true;
-                    me->ClearTarget();
-                    return;
+                    if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofFortitude))
+                    {
+                        if (DoCastSpell(pTarget, m_spells.priest.pPrayerofFortitude) == SPELL_CAST_OK)
+                        {
+                            m_isBuffing = true;
+                            me->ClearTarget();
+                            return;
+                        }
+                    }
+                    else if (InsufficientPowerForBuffSpell(me, m_spells.priest.pPrayerofFortitude))
+                        skipFortitudeSingle = true;
                 }
             }
-        }
-    }
-    else if (m_spells.priest.pPowerWordFortitude)
-    {
-        if (Player* pTarget = SelectBuffTarget(m_spells.priest.pPowerWordFortitude))
-        {
-            if (CanTryToCastSpell(pTarget, m_spells.priest.pPowerWordFortitude))
+            if (!skipFortitudeSingle && m_spells.priest.pPowerWordFortitude)
             {
-                if (DoCastSpell(pTarget, m_spells.priest.pPowerWordFortitude) == SPELL_CAST_OK)
+                if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pPowerWordFortitude, m_spells.priest.pPrayerofFortitude))
                 {
-                    m_isBuffing = true;
-                    me->ClearTarget();
-                    return;
+                    if (CanTryToCastSpell(pTarget, m_spells.priest.pPowerWordFortitude))
+                    {
+                        if (DoCastSpell(pTarget, m_spells.priest.pPowerWordFortitude) == SPELL_CAST_OK)
+                        {
+                            m_isBuffing = true;
+                            me->ClearTarget();
+                            return;
+                        }
+                    }
                 }
             }
-        }
-    }
-
-    if (m_spells.priest.pPrayerofSpirit)
-    {
-        if (Player* pTarget = SelectBuffTarget(m_spells.priest.pPrayerofSpirit))
-        {
-            if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofSpirit))
+            else if (!skipFortitudeSingle && m_spells.priest.pPrayerofFortitude && !m_spells.priest.pPowerWordFortitude)
             {
-                if (DoCastSpell(pTarget, m_spells.priest.pPrayerofSpirit) == SPELL_CAST_OK)
+                if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pPowerWordFortitude, m_spells.priest.pPrayerofFortitude))
                 {
-                    m_isBuffing = true;
-                    me->ClearTarget();
-                    return;
-                }
-            }
-        }
-    }
-    else if (m_spells.priest.pDivineSpirit)
-    {
-        if (Player* pTarget = SelectBuffTarget(m_spells.priest.pDivineSpirit))
-        {
-            if (CanTryToCastSpell(me, m_spells.priest.pDivineSpirit))
-            {
-                if (DoCastSpell(me, m_spells.priest.pDivineSpirit) == SPELL_CAST_OK)
-                {
-                    m_isBuffing = true;
-                    me->ClearTarget();
-                    return;
+                    if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofFortitude))
+                    {
+                        if (DoCastSpell(pTarget, m_spells.priest.pPrayerofFortitude) == SPELL_CAST_OK)
+                        {
+                            m_isBuffing = true;
+                            me->ClearTarget();
+                            return;
+                        }
+                    }
                 }
             }
         }
     }
 
-    if (m_spells.priest.pPrayerofShadowProtection)
+    if (m_spells.priest.pDivineSpirit || m_spells.priest.pPrayerofSpirit)
     {
-        if (Player* pTarget = SelectBuffTarget(m_spells.priest.pPrayerofShadowProtection))
+        uint32 spiritNeed = CountPlayersNeedingBuffLine(m_spells.priest.pDivineSpirit, m_spells.priest.pPrayerofSpirit);
+        if (spiritNeed > 0)
         {
-            if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofShadowProtection))
+            bool skipSpiritSingle = false;
+            if (spiritNeed >= 2 && m_spells.priest.pPrayerofSpirit)
             {
-                if (DoCastSpell(pTarget, m_spells.priest.pPrayerofShadowProtection) == SPELL_CAST_OK)
+                if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pDivineSpirit, m_spells.priest.pPrayerofSpirit))
                 {
-                    m_isBuffing = true;
-                    me->ClearTarget();
-                    return;
+                    if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofSpirit))
+                    {
+                        if (DoCastSpell(pTarget, m_spells.priest.pPrayerofSpirit) == SPELL_CAST_OK)
+                        {
+                            m_isBuffing = true;
+                            me->ClearTarget();
+                            return;
+                        }
+                    }
+                    else if (InsufficientPowerForBuffSpell(me, m_spells.priest.pPrayerofSpirit))
+                        skipSpiritSingle = true;
+                }
+            }
+            if (!skipSpiritSingle && m_spells.priest.pDivineSpirit)
+            {
+                if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pDivineSpirit, m_spells.priest.pPrayerofSpirit))
+                {
+                    if (CanTryToCastSpell(pTarget, m_spells.priest.pDivineSpirit))
+                    {
+                        if (DoCastSpell(pTarget, m_spells.priest.pDivineSpirit) == SPELL_CAST_OK)
+                        {
+                            m_isBuffing = true;
+                            me->ClearTarget();
+                            return;
+                        }
+                    }
+                }
+            }
+            else if (!skipSpiritSingle && m_spells.priest.pPrayerofSpirit && !m_spells.priest.pDivineSpirit)
+            {
+                if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pDivineSpirit, m_spells.priest.pPrayerofSpirit))
+                {
+                    if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofSpirit))
+                    {
+                        if (DoCastSpell(pTarget, m_spells.priest.pPrayerofSpirit) == SPELL_CAST_OK)
+                        {
+                            m_isBuffing = true;
+                            me->ClearTarget();
+                            return;
+                        }
+                    }
                 }
             }
         }
     }
-    else
-    if (m_spells.priest.pShadowProtection)
+
+    if (m_spells.priest.pShadowProtection || m_spells.priest.pPrayerofShadowProtection)
     {
-        if (Player* pTarget = SelectBuffTarget(m_spells.priest.pShadowProtection))
+        uint32 shadowNeed = CountPlayersNeedingBuffLine(m_spells.priest.pShadowProtection, m_spells.priest.pPrayerofShadowProtection);
+        if (shadowNeed > 0)
         {
-            if (CanTryToCastSpell(pTarget, m_spells.priest.pShadowProtection))
+            bool skipShadowProtSingle = false;
+            if (shadowNeed >= 2 && m_spells.priest.pPrayerofShadowProtection)
             {
-                if (DoCastSpell(pTarget, m_spells.priest.pShadowProtection) == SPELL_CAST_OK)
+                if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pShadowProtection, m_spells.priest.pPrayerofShadowProtection))
                 {
-                    m_isBuffing = true;
-                    me->ClearTarget();
-                    return;
+                    if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofShadowProtection))
+                    {
+                        if (DoCastSpell(pTarget, m_spells.priest.pPrayerofShadowProtection) == SPELL_CAST_OK)
+                        {
+                            m_isBuffing = true;
+                            me->ClearTarget();
+                            return;
+                        }
+                    }
+                    else if (InsufficientPowerForBuffSpell(me, m_spells.priest.pPrayerofShadowProtection))
+                        skipShadowProtSingle = true;
+                }
+            }
+            if (!skipShadowProtSingle && m_spells.priest.pShadowProtection)
+            {
+                if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pShadowProtection, m_spells.priest.pPrayerofShadowProtection))
+                {
+                    if (CanTryToCastSpell(pTarget, m_spells.priest.pShadowProtection))
+                    {
+                        if (DoCastSpell(pTarget, m_spells.priest.pShadowProtection) == SPELL_CAST_OK)
+                        {
+                            m_isBuffing = true;
+                            me->ClearTarget();
+                            return;
+                        }
+                    }
+                }
+            }
+            else if (!skipShadowProtSingle && m_spells.priest.pPrayerofShadowProtection && !m_spells.priest.pShadowProtection)
+            {
+                if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.priest.pShadowProtection, m_spells.priest.pPrayerofShadowProtection))
+                {
+                    if (CanTryToCastSpell(pTarget, m_spells.priest.pPrayerofShadowProtection))
+                    {
+                        if (DoCastSpell(pTarget, m_spells.priest.pPrayerofShadowProtection) == SPELL_CAST_OK)
+                        {
+                            m_isBuffing = true;
+                            me->ClearTarget();
+                            return;
+                        }
+                    }
                 }
             }
         }
@@ -3912,32 +4182,57 @@ void PartyBotAI::UpdateOutOfCombatAI_Druid()
         return;
     }
 
-    if (m_spells.druid.pGiftoftheWild)
+    if (m_spells.druid.pMarkoftheWild || m_spells.druid.pGiftoftheWild)
     {
-        if (Player* pTarget = SelectBuffTarget(m_spells.druid.pGiftoftheWild))
+        uint32 motwNeed = CountPlayersNeedingBuffLine(m_spells.druid.pMarkoftheWild, m_spells.druid.pGiftoftheWild);
+        if (motwNeed > 0)
         {
-            if (CanTryToCastSpell(pTarget, m_spells.druid.pGiftoftheWild))
+            bool skipMotWSingle = false;
+            if (motwNeed >= 2 && m_spells.druid.pGiftoftheWild)
             {
-                if (DoCastSpell(pTarget, m_spells.druid.pGiftoftheWild) == SPELL_CAST_OK)
+                if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.druid.pMarkoftheWild, m_spells.druid.pGiftoftheWild))
                 {
-                    m_isBuffing = true;
-                    me->ClearTarget();
-                    return;
+                    if (CanTryToCastSpell(pTarget, m_spells.druid.pGiftoftheWild))
+                    {
+                        if (DoCastSpell(pTarget, m_spells.druid.pGiftoftheWild) == SPELL_CAST_OK)
+                        {
+                            m_isBuffing = true;
+                            me->ClearTarget();
+                            return;
+                        }
+                    }
+                    else if (InsufficientPowerForBuffSpell(me, m_spells.druid.pGiftoftheWild))
+                        skipMotWSingle = true;
                 }
             }
-        }
-    }
-    else if (m_spells.druid.pMarkoftheWild)
-    {
-        if (Player* pTarget = SelectBuffTarget(m_spells.druid.pMarkoftheWild))
-        {
-            if (CanTryToCastSpell(pTarget, m_spells.druid.pMarkoftheWild))
+            if (!skipMotWSingle && m_spells.druid.pMarkoftheWild)
             {
-                if (DoCastSpell(pTarget, m_spells.druid.pMarkoftheWild) == SPELL_CAST_OK)
+                if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.druid.pMarkoftheWild, m_spells.druid.pGiftoftheWild))
                 {
-                    m_isBuffing = true;
-                    me->ClearTarget();
-                    return;
+                    if (CanTryToCastSpell(pTarget, m_spells.druid.pMarkoftheWild))
+                    {
+                        if (DoCastSpell(pTarget, m_spells.druid.pMarkoftheWild) == SPELL_CAST_OK)
+                        {
+                            m_isBuffing = true;
+                            me->ClearTarget();
+                            return;
+                        }
+                    }
+                }
+            }
+            else if (!skipMotWSingle && m_spells.druid.pGiftoftheWild && !m_spells.druid.pMarkoftheWild)
+            {
+                if (Player* pTarget = SelectBuffTargetForBuffLine(m_spells.druid.pMarkoftheWild, m_spells.druid.pGiftoftheWild))
+                {
+                    if (CanTryToCastSpell(pTarget, m_spells.druid.pGiftoftheWild))
+                    {
+                        if (DoCastSpell(pTarget, m_spells.druid.pGiftoftheWild) == SPELL_CAST_OK)
+                        {
+                            m_isBuffing = true;
+                            me->ClearTarget();
+                            return;
+                        }
+                    }
                 }
             }
         }

--- a/src/game/PlayerBots/PartyBotAI.h
+++ b/src/game/PlayerBots/PartyBotAI.h
@@ -78,6 +78,9 @@ public:
     bool NeedsToBuffAlly() const;
     bool TryBuffAlly();
     uint32 CountPlayersNeedingBuff(SpellEntry const* pSpellEntry) const;
+    uint32 CountPlayersNeedingBuffLine(SpellEntry const* pSingleTargetSpell, SpellEntry const* pGroupBuffSpell) const;
+    Player* SelectBuffTargetForBuffLine(SpellEntry const* pSingleTargetSpell, SpellEntry const* pGroupBuffSpell) const;
+    bool TargetLacksBuffLine(Unit const* pTarget, SpellEntry const* pSingleTargetSpell, SpellEntry const* pGroupBuffSpell) const;
     Unit* GetMarkedTarget(RaidTargetIcon mark) const;
     bool CanUseCrowdControl(SpellEntry const* pSpellEntry, Unit* pTarget) const;
     bool DrinkAndEat();

--- a/src/game/PlayerBots/PlayerBotMgr.cpp
+++ b/src/game/PlayerBots/PlayerBotMgr.cpp
@@ -1113,9 +1113,9 @@ bool PlayerBotMgr::CloneOfflinePlayer(Player* pPlayer, ObjectGuid guid)
 
     // Clone equipment
     std::istringstream iss(equipmentCache);
-    uint32 itemId, enchantId;
+    uint32 itemId, packedEnchants;
     uint32 slot = EQUIPMENT_SLOT_START;
-    while (iss >> itemId >> enchantId)
+    while (iss >> itemId >> packedEnchants)
     {
         if (slot < EQUIPMENT_SLOT_END)
         {
@@ -1125,12 +1125,21 @@ bool PlayerBotMgr::CloneOfflinePlayer(Player* pPlayer, ObjectGuid guid)
                 Item* pItem = newChar->EquipNewItem(slot, itemId, true);
                 if (pItem)
                 {
-                    if (enchantId)
+                    uint32 const permEnchant = PAIR32_LOPART(packedEnchants);
+                    uint32 const tempEnchamt = PAIR32_HIPART(packedEnchants);
+                    if (permEnchant)
                     {
                         pItem->ClearEnchantment(PERM_ENCHANTMENT_SLOT);
-                        pItem->SetEnchantment(PERM_ENCHANTMENT_SLOT, enchantId, 0, 0);
+                        pItem->SetEnchantment(PERM_ENCHANTMENT_SLOT, permEnchant, 0, 0);
                         pItem->SetState(ITEM_CHANGED, newChar);
                         newChar->ApplyEnchantment(pItem, PERM_ENCHANTMENT_SLOT, true);
+                    }
+                    if (tempEnchamt)
+                    {
+                        pItem->ClearEnchantment(TEMP_ENCHANTMENT_SLOT);
+                        pItem->SetEnchantment(TEMP_ENCHANTMENT_SLOT, tempEnchamt, 0, 0);
+                        pItem->SetState(ITEM_CHANGED, newChar);
+                        newChar->ApplyEnchantment(pItem, TEMP_ENCHANTMENT_SLOT, true);
                     }
                 }
                 else


### PR DESCRIPTION
### Cause
For priest/druid “buff lines” (Fortitude / Spirit / Shadow Prot / Mark), when two or more party members needed the buff the code tried the group spell first. If CanTryToCastSpell failed (most often not enough mana), execution fell through to the cheaper single-target spell, so the bot started single-buffing as soon as it had mana for that instead of saving up for the prayer/gift.

### Change

- Added `InsufficientPowerForBuffSpell` - same cost check as `CombatBotBaseAI::CanTryToCastSpell` (via `Spell::CalculatePowerCost`).

- **When count of players needing a buff line is greater than or equal to 2:**
  - If the group cast is not ready and current power is below the group spell’s cost, set a skip single flag for that line.
  - Do not consider or cast the single-target rank for that line while that flag is set, so `NeedsToBuffAlly()` can stay false and the bot can drink/regen until the group cast is affordable.
* The `else if` “prayer only / no single rank” branches were tightened with `!skip… && … && !singleSpell` so we never re-enter the group path as a fallback after we deliberately skipped singles (same structure as the original `else if` meaning).

- Mirrored the same behavior in `TryBuffAlly`, `UpdateOutOfCombatAI_Priest`, and `UpdateOutOfCombatAI_Druid` so behavior stays consistent everywhere those buffs are applied.