### PR TITLE
Paladin buff enhancements

### DIFF
--- a/src/game/PlayerBots/BattleBotAI.cpp
+++ b/src/game/PlayerBots/BattleBotAI.cpp
@@ -1279,16 +1279,17 @@ void BattleBotAI::UpdateOutOfCombatAI_Paladin()
 
     if (m_spells.paladin.pBlessingBuff)
     {
-        if (Player* pTarget = SelectBuffTarget(m_spells.paladin.pBlessingBuff))
+        SpellEntry const* pBlessing = nullptr;
+        if (Player* pTarget = SelectPaladinBlessingBuffTarget(pBlessing))
         {
-            if (CanTryToCastSpell(pTarget, m_spells.paladin.pBlessingBuff))
+            if (CanTryToCastSpell(pTarget, pBlessing))
             {
-                if (DoCastSpell(pTarget, m_spells.paladin.pBlessingBuff) == SPELL_CAST_OK)
+                if (DoCastSpell(pTarget, pBlessing) == SPELL_CAST_OK)
                 {
                     m_isBuffing = true;
                     return;
                 }
-            }  
+            }
         }
     }
 

--- a/src/game/PlayerBots/CombatBotBaseAI.cpp
+++ b/src/game/PlayerBots/CombatBotBaseAI.cpp
@@ -174,6 +174,7 @@ void CombatBotBaseAI::PopulateSpellData()
     SpellEntry const* pConcentrationAura = nullptr;
     SpellEntry const* pRetributionAura = nullptr;
     SpellEntry const* pSanctityAura = nullptr;
+    SpellEntry const* pValianceAura = nullptr;
     SpellEntry const* pShadowResistanceAura = nullptr;
     SpellEntry const* pFrostResistanceAura = nullptr;
     SpellEntry const* pFireResistanceAura = nullptr;
@@ -364,6 +365,11 @@ void CombatBotBaseAI::PopulateSpellData()
                 {
                     if (IsHigherRankSpell(pSanctityAura))
                         pSanctityAura = pSpellEntry;
+                }
+                else if (pSpellEntry->SpellName[0].find("Valiance Aura") != std::string::npos)
+                {
+                    if (IsHigherRankSpell(pValianceAura))
+                        pValianceAura = pSpellEntry;
                 }
                 else if (pSpellEntry->SpellName[0].find("Shadow Resistance Aura") != std::string::npos)
                 {
@@ -1772,6 +1778,11 @@ void CombatBotBaseAI::PopulateSpellData()
                 if (!auras.empty())
                     m_spells.paladin.pAura = SelectRandomContainerElement(auras);
             }
+            m_spells.paladin.pDevotionAura = pDevotionAura;
+            m_spells.paladin.pRetributionAura = pRetributionAura;
+            m_spells.paladin.pConcentrationAura = pConcentrationAura;
+            m_spells.paladin.pSanctityAura = pSanctityAura;
+            m_spells.paladin.pValianceAura = pValianceAura;
             break;
         }
         case CLASS_SHAMAN:

--- a/src/game/PlayerBots/CombatBotBaseAI.cpp
+++ b/src/game/PlayerBots/CombatBotBaseAI.cpp
@@ -131,6 +131,25 @@ void CombatBotBaseAI::ResetSpellData()
     m_spellListTaunt.clear();
 }
 
+// Helper to pick the first spell in each preference list that the bot actually knows
+inline SpellEntry const* PickFirstPaladinBlessing(
+    SpellEntry const* a,
+    SpellEntry const* b = nullptr,
+    SpellEntry const* c = nullptr,
+    SpellEntry const* d = nullptr,
+    SpellEntry const* e = nullptr)
+{
+    if (a)
+        return a;
+    if (b)
+        return b;
+    if (c)
+        return c;
+    if (d)
+        return d;
+    return e;
+}
+
 void CombatBotBaseAI::PopulateSpellData()
 {
     // Paladin Seals
@@ -144,6 +163,11 @@ void CombatBotBaseAI::PopulateSpellData()
     SpellEntry const* pBlessingOfWisdom = nullptr;
     SpellEntry const* pBlessingOfKings = nullptr;
     SpellEntry const* pBlessingOfSanctuary = nullptr;
+    SpellEntry const* pGreaterBlessingOfLight = nullptr;
+    SpellEntry const* pGreaterBlessingOfMight = nullptr;
+    SpellEntry const* pGreaterBlessingOfWisdom = nullptr;
+    SpellEntry const* pGreaterBlessingOfKings = nullptr;
+    SpellEntry const* pGreaterBlessingOfSanctuary = nullptr;
 
     // Paladin Auras
     SpellEntry const* pDevotionAura = nullptr;
@@ -271,25 +295,50 @@ void CombatBotBaseAI::PopulateSpellData()
                     if (IsHigherRankSpell(m_spells.paladin.pBlessingOfProtection))
                         m_spells.paladin.pBlessingOfProtection = pSpellEntry;
                 }
+                else if (pSpellEntry->SpellName[0].find("Greater Blessing of Sanctuary") != std::string::npos)
+                {
+                    if (IsHigherRankSpell(pGreaterBlessingOfSanctuary))
+                        pGreaterBlessingOfSanctuary = pSpellEntry;
+                }
                 else if (pSpellEntry->SpellName[0].find("Blessing of Sanctuary") != std::string::npos)
                 {
                     if (IsHigherRankSpell(pBlessingOfSanctuary))
                         pBlessingOfSanctuary = pSpellEntry;
+                }
+                else if (pSpellEntry->SpellName[0].find("Greater Blessing of Kings") != std::string::npos)
+                {
+                    if (IsHigherRankSpell(pGreaterBlessingOfKings))
+                        pGreaterBlessingOfKings = pSpellEntry;
                 }
                 else if (pSpellEntry->SpellName[0].find("Blessing of Kings") != std::string::npos)
                 {
                     if (IsHigherRankSpell(pBlessingOfKings))
                         pBlessingOfKings = pSpellEntry;
                 }
+                else if (pSpellEntry->SpellName[0].find("Greater Blessing of Wisdom") != std::string::npos)
+                {
+                    if (IsHigherRankSpell(pGreaterBlessingOfWisdom))
+                        pGreaterBlessingOfWisdom = pSpellEntry;
+                }
                 else if (pSpellEntry->SpellName[0].find("Blessing of Wisdom") != std::string::npos)
                 {
                     if (IsHigherRankSpell(pBlessingOfWisdom))
                         pBlessingOfWisdom = pSpellEntry;
                 }
+                else if (pSpellEntry->SpellName[0].find("Greater Blessing of Might") != std::string::npos)
+                {
+                    if (IsHigherRankSpell(pGreaterBlessingOfMight))
+                        pGreaterBlessingOfMight = pSpellEntry;
+                }
                 else if (pSpellEntry->SpellName[0].find("Blessing of Might") != std::string::npos)
                 {
                     if (IsHigherRankSpell(pBlessingOfMight))
                         pBlessingOfMight = pSpellEntry;
+                }
+                else if (pSpellEntry->SpellName[0].find("Greater Blessing of Light") != std::string::npos)
+                {
+                    if (IsHigherRankSpell(pGreaterBlessingOfLight))
+                        pGreaterBlessingOfLight = pSpellEntry;
                 }
                 else if (pSpellEntry->SpellName[0].find("Blessing of Light") != std::string::npos)
                 {
@@ -1674,22 +1723,30 @@ void CombatBotBaseAI::PopulateSpellData()
             else
                 m_spells.paladin.pSeal = pSealOfRighteousness;
 
-            if (pBlessingOfSanctuary && m_role == ROLE_TANK)
-                m_spells.paladin.pBlessingBuff = pBlessingOfSanctuary;
-            else if (pBlessingOfKings)
-                m_spells.paladin.pBlessingBuff = pBlessingOfKings;
-            else    
-            {
-                std::vector<SpellEntry const*> blessings;
-                if (pBlessingOfLight)
-                    blessings.push_back(pBlessingOfLight);
-                if (pBlessingOfMight)
-                    blessings.push_back(pBlessingOfMight);
-                if (pBlessingOfWisdom)
-                    blessings.push_back(pBlessingOfWisdom);
-                if (!blessings.empty())
-                    m_spells.paladin.pBlessingBuff = SelectRandomContainerElement(blessings);
-            }
+            m_spells.paladin.pBlessingOfSanctuary = pBlessingOfSanctuary;
+            m_spells.paladin.pBlessingOfKings = pBlessingOfKings;
+            m_spells.paladin.pBlessingOfLight = pBlessingOfLight;
+            m_spells.paladin.pBlessingOfMight = pBlessingOfMight;
+            m_spells.paladin.pBlessingOfWisdom = pBlessingOfWisdom;
+            m_spells.paladin.pGreaterBlessingOfSanctuary = pGreaterBlessingOfSanctuary;
+            m_spells.paladin.pGreaterBlessingOfKings = pGreaterBlessingOfKings;
+            m_spells.paladin.pGreaterBlessingOfLight = pGreaterBlessingOfLight;
+            m_spells.paladin.pGreaterBlessingOfMight = pGreaterBlessingOfMight;
+            m_spells.paladin.pGreaterBlessingOfWisdom = pGreaterBlessingOfWisdom;
+            // Any known blessing (greater or normal) for GCD / "has blessing spells" checks
+            m_spells.paladin.pBlessingBuff = PickFirstPaladinBlessing(
+                m_spells.paladin.pGreaterBlessingOfSanctuary,
+                m_spells.paladin.pBlessingOfSanctuary,
+                m_spells.paladin.pGreaterBlessingOfKings,
+                m_spells.paladin.pBlessingOfKings,
+                m_spells.paladin.pGreaterBlessingOfLight);
+            if (!m_spells.paladin.pBlessingBuff)
+                m_spells.paladin.pBlessingBuff = PickFirstPaladinBlessing(
+                    m_spells.paladin.pBlessingOfLight,
+                    m_spells.paladin.pGreaterBlessingOfMight,
+                    m_spells.paladin.pBlessingOfMight,
+                    m_spells.paladin.pGreaterBlessingOfWisdom,
+                    m_spells.paladin.pBlessingOfWisdom);
             if (pDevotionAura && m_role == ROLE_TANK)
                 m_spells.paladin.pAura = pDevotionAura;
             else if (pConcentrationAura && m_role == ROLE_HEALER)
@@ -2279,6 +2336,103 @@ Player* CombatBotBaseAI::SelectBuffTarget(SpellEntry const* pSpellEntry) const
                     me->IsWithinDist(pMember, 30.0f))
                     return pMember;
             }
+        }
+    }
+
+    return nullptr;
+}
+
+// Choose which blessing spell to cast on pTarget (greater rank preferred when known).
+SpellEntry const* CombatBotBaseAI::SelectPaladinBlessingSpellForTarget(Player const* pTarget) const
+{
+    if (!pTarget || me->GetClass() != CLASS_PALADIN)
+        return nullptr;
+
+    SpellEntry const* const sanc = PickFirstPaladinBlessing(
+        m_spells.paladin.pGreaterBlessingOfSanctuary,
+        m_spells.paladin.pBlessingOfSanctuary);
+    SpellEntry const* const light = PickFirstPaladinBlessing(
+        m_spells.paladin.pGreaterBlessingOfLight,
+        m_spells.paladin.pBlessingOfLight);
+    SpellEntry const* const kings = PickFirstPaladinBlessing(
+        m_spells.paladin.pGreaterBlessingOfKings,
+        m_spells.paladin.pBlessingOfKings);
+    SpellEntry const* const might = PickFirstPaladinBlessing(
+        m_spells.paladin.pGreaterBlessingOfMight,
+        m_spells.paladin.pBlessingOfMight);
+    SpellEntry const* const wisdom = PickFirstPaladinBlessing(
+        m_spells.paladin.pGreaterBlessingOfWisdom,
+        m_spells.paladin.pBlessingOfWisdom);
+
+    // Prot paladin: mitigation first, then Light, then stats.
+    if (pTarget->HasSpell(SPELL_HOLY_SHIELD))
+        return PickFirstPaladinBlessing(sanc, light, kings, wisdom, might);
+
+    uint8 const cls = pTarget->GetClass();
+    switch (cls)
+    {
+        // Physical DPS: Might, then Kings
+        case CLASS_WARRIOR:
+        case CLASS_ROGUE:
+            return PickFirstPaladinBlessing(might, kings);
+        // Hunter
+        case CLASS_HUNTER:
+            return PickFirstPaladinBlessing(kings, wisdom);
+        // Mana casters / healers
+        case CLASS_MAGE:
+        case CLASS_WARLOCK:
+        case CLASS_PRIEST:
+            return PickFirstPaladinBlessing(wisdom, kings);
+        case CLASS_SHAMAN:
+            // treat like physical; else caster/resto.
+            if (pTarget->HasSpell(SPELL_STORMSTRIKE))
+                return PickFirstPaladinBlessing(might, kings);
+            return PickFirstPaladinBlessing(wisdom, kings);
+        case CLASS_DRUID:
+            // Balance
+            if (pTarget->HasSpell(SPELL_MOONKIN_FORM))
+                return PickFirstPaladinBlessing(wisdom, kings, might);
+            // Feral
+            if (pTarget->HasSpell(SPELL_LEADER_OF_THE_PACK))
+                return PickFirstPaladinBlessing(might, kings, wisdom);
+            return PickFirstPaladinBlessing(wisdom, kings, might);
+        case CLASS_PALADIN:
+            // Ret: Might. Holy / generic: Wisdom.
+            if (pTarget->HasSpell(SPELL_SANCTITY_AURA))
+                return PickFirstPaladinBlessing(might, kings, wisdom);
+            return PickFirstPaladinBlessing(wisdom, kings, might);
+        default:
+            // Unknown class: Kings is the usual group default, then Might / Wisdom.
+            return PickFirstPaladinBlessing(kings, might, wisdom);
+    }
+}
+
+Player* CombatBotBaseAI::SelectPaladinBlessingBuffTarget(SpellEntry const*& outSpell) const
+{
+    outSpell = nullptr;
+    if (me->GetClass() != CLASS_PALADIN || !m_spells.paladin.pBlessingBuff)
+        return nullptr;
+
+    Group* pGroup = me->GetGroup();
+    if (!pGroup)
+        return nullptr;
+
+    for (GroupReference* itr = pGroup->GetFirstMember(); itr != nullptr; itr = itr->next())
+    {
+        if (Player* pMember = itr->getSource())
+        {
+            if (!me->IsValidHelpfulTarget(pMember) ||
+                pMember->IsGameMaster() ||
+                !me->IsWithinLOSInMap(pMember) ||
+                !me->IsWithinDist(pMember, 30.0f))
+                continue;
+
+            SpellEntry const* pBlessing = SelectPaladinBlessingSpellForTarget(pMember);
+            if (!pBlessing || !IsValidBuffTarget(pMember, pBlessing))
+                continue;
+
+            outSpell = pBlessing;
+            return pMember;
         }
     }
 

--- a/src/game/PlayerBots/CombatBotBaseAI.h
+++ b/src/game/PlayerBots/CombatBotBaseAI.h
@@ -104,6 +104,8 @@ public:
     Unit* SelectHealTarget(float selfHealPercent = 100.0f, float groupHealPercent = 100.0f) const;
     Unit* SelectPeriodicHealTarget(float selfHealPercent = 100.0f, float groupHealPercent = 100.0f) const;
     Player* SelectBuffTarget(SpellEntry const* pSpellEntry) const;
+    SpellEntry const* SelectPaladinBlessingSpellForTarget(Player const* pTarget) const;
+    Player* SelectPaladinBlessingBuffTarget(SpellEntry const*& outSpell) const;
     Player* SelectDispelTarget(SpellEntry const* pSpellEntry) const;
     bool IsValidBuffTarget(Unit const* pTarget, SpellEntry const* pSpellEntry) const;
     bool IsValidHealTarget(Unit const* pTarget, float healthPercent = 100.0f) const;
@@ -292,6 +294,16 @@ public:
             SpellEntry const* pAura;
             SpellEntry const* pSeal;
             SpellEntry const* pBlessingBuff;
+            SpellEntry const* pBlessingOfLight;
+            SpellEntry const* pBlessingOfMight;
+            SpellEntry const* pBlessingOfWisdom;
+            SpellEntry const* pBlessingOfKings;
+            SpellEntry const* pBlessingOfSanctuary;
+            SpellEntry const* pGreaterBlessingOfLight;
+            SpellEntry const* pGreaterBlessingOfMight;
+            SpellEntry const* pGreaterBlessingOfWisdom;
+            SpellEntry const* pGreaterBlessingOfKings;
+            SpellEntry const* pGreaterBlessingOfSanctuary;
             SpellEntry const* pBlessingOfProtection;
             SpellEntry const* pBlessingOfFreedom;
             SpellEntry const* pBlessingOfSacrifice;
@@ -315,7 +327,6 @@ public:
             SpellEntry const* pDevotionAura;
             SpellEntry const* pConcentrationAura;
             SpellEntry const* pSanctityAura;
-            SpellEntry const* pBlessingOfSanctuary;
             SpellEntry const* pValianceAura;
         } paladin;
         struct

--- a/src/game/PlayerBots/CombatBotBaseAI.h
+++ b/src/game/PlayerBots/CombatBotBaseAI.h
@@ -325,6 +325,7 @@ public:
             SpellEntry const* pRepentance;
             SpellEntry const* pGeas;
             SpellEntry const* pDevotionAura;
+            SpellEntry const* pRetributionAura;
             SpellEntry const* pConcentrationAura;
             SpellEntry const* pSanctityAura;
             SpellEntry const* pValianceAura;

--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -832,9 +832,10 @@ bool PartyBotAI::NeedsToBuffAlly() const
         case CLASS_PALADIN:
             if (m_spells.paladin.pBlessingBuff)
             {
-                if (Player* pTarget = SelectBuffTarget(m_spells.paladin.pBlessingBuff))
+                SpellEntry const* pBlessing = nullptr;
+                if (Player* pTarget = SelectPaladinBlessingBuffTarget(pBlessing))
                 {
-                    if (CanTryToCastSpell(pTarget, m_spells.paladin.pBlessingBuff))
+                    if (CanTryToCastSpell(pTarget, pBlessing))
                         return true;
                 }
             }
@@ -1049,11 +1050,12 @@ bool PartyBotAI::TryBuffAlly()
         case CLASS_PALADIN:
             if (m_spells.paladin.pBlessingBuff)
             {
-                if (Player* pTarget = SelectBuffTarget(m_spells.paladin.pBlessingBuff))
+                SpellEntry const* pBlessing = nullptr;
+                if (Player* pTarget = SelectPaladinBlessingBuffTarget(pBlessing))
                 {
-                    if (CanTryToCastSpell(pTarget, m_spells.paladin.pBlessingBuff))
+                    if (CanTryToCastSpell(pTarget, pBlessing))
                     {
-                        if (DoCastSpell(pTarget, m_spells.paladin.pBlessingBuff) == SPELL_CAST_OK)
+                        if (DoCastSpell(pTarget, pBlessing) == SPELL_CAST_OK)
                         {
                             m_isBuffing = true;
                             me->ClearTarget();
@@ -2109,17 +2111,18 @@ void PartyBotAI::UpdateOutOfCombatAI_Paladin()
 
     if (m_spells.paladin.pBlessingBuff)
     {
-        if (Player* pTarget = SelectBuffTarget(m_spells.paladin.pBlessingBuff))
+        SpellEntry const* pBlessing = nullptr;
+        if (Player* pTarget = SelectPaladinBlessingBuffTarget(pBlessing))
         {
-            if (CanTryToCastSpell(pTarget, m_spells.paladin.pBlessingBuff))
+            if (CanTryToCastSpell(pTarget, pBlessing))
             {
-                if (DoCastSpell(pTarget, m_spells.paladin.pBlessingBuff) == SPELL_CAST_OK)
+                if (DoCastSpell(pTarget, pBlessing) == SPELL_CAST_OK)
                 {
                     m_isBuffing = true;
                     me->ClearTarget();
                     return;
                 }
-            }  
+            }
         }
     }
 

--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -1471,6 +1471,45 @@ void PartyBotAI::SetOwner(Player* pOwner)
     AddToPlayerGroup();
 }
 
+void PartyBotAI::ApplySavedPaladinAuraPreference()
+{
+    if (me->GetClass() != CLASS_PALADIN || !m_paladinAuraPreference)
+        return;
+    m_spells.paladin.pAura = m_paladinAuraPreference;
+}
+
+bool PartyBotAI::TryApplyPaladinAura(std::string const& messageLower, std::string* outChosenAuraName)
+{
+    if (me->GetClass() != CLASS_PALADIN)
+        return false;
+
+    SpellEntry const* aura = nullptr;
+    if (messageLower.find("devotion") != std::string::npos || messageLower.find("devo") != std::string::npos)
+        aura = m_spells.paladin.pDevotionAura;
+    else if (messageLower.find("concentration") != std::string::npos || messageLower.find("conc") != std::string::npos)
+        aura = m_spells.paladin.pConcentrationAura;
+    else if (messageLower.find("sanctity") != std::string::npos || messageLower.find("sanc") != std::string::npos)
+        aura = m_spells.paladin.pSanctityAura;
+    else if (messageLower.find("retribution") != std::string::npos || messageLower.find("ret") != std::string::npos)
+        aura = m_spells.paladin.pRetributionAura;
+    else if (messageLower.find("valiance") != std::string::npos || messageLower.find("val") != std::string::npos)
+        aura = m_spells.paladin.pValianceAura;
+
+    if (!aura)
+        return false;
+
+    m_paladinAuraPreference = aura;
+    m_spells.paladin.pAura = aura;
+
+    if (outChosenAuraName)
+        *outChosenAuraName = aura->SpellName[0];
+
+    if (CanTryToCastSpell(me, aura))
+        DoCastSpell(me, aura);
+
+    return true;
+}
+
 void PartyBotAI::OnPacketReceived(WorldPacket const* packet)
 {
     //printf("Bot received %s\n", LookupOpcodeName(packet->GetOpcode()));
@@ -1579,6 +1618,7 @@ void PartyBotAI::UpdateAI(uint32 const diff)
 
         ResetSpellData();
         PopulateSpellData();
+        ApplySavedPaladinAuraPreference();
         AddAllSpellReagents();
         me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_SPAWNING);
         SummonPetIfNeeded();
@@ -1600,6 +1640,7 @@ void PartyBotAI::UpdateAI(uint32 const diff)
     {
         ResetSpellData();
         PopulateSpellData();
+        ApplySavedPaladinAuraPreference();
         m_resetSpellData = false;
     }
 

--- a/src/game/PlayerBots/PartyBotAI.h
+++ b/src/game/PlayerBots/PartyBotAI.h
@@ -17,6 +17,8 @@
 #ifndef MANGOS_PARTYBOTAI_H
 #define MANGOS_PARTYBOTAI_H
 
+#include <string>
+
 #include "CombatBotBaseAI.h"
 #include "Group.h"
 #include "ObjectAccessor.h"
@@ -65,6 +67,8 @@ public:
     void CloneFromPlayer(Player const* pPlayer);
     void AddToPlayerGroup();
     void SetOwner(Player* pOwner);
+
+    bool TryApplyPaladinAura(std::string const& messageLower, std::string* outChosenAuraName = nullptr);
 
     bool CanTryToCastSpell(Unit const* pTarget, SpellEntry const* pSpellEntry) const final;
     Player* GetPartyLeader() const;
@@ -145,7 +149,9 @@ public:
     bool m_isStaying = false;
     bool m_leaderReleased = false;
     bool m_isBuffing = false;
+    SpellEntry const* m_paladinAuraPreference = nullptr;
 
+    void ApplySavedPaladinAuraPreference();
     void SendPartyChat(const char* msg, uint32 delay = 0);
     void SetChatCooldown(uint32 seconds);
 };

--- a/src/game/PlayerBots/PartyBotChat.cpp
+++ b/src/game/PlayerBots/PartyBotChat.cpp
@@ -226,6 +226,35 @@ void PartyBotChat::ProcessPartyMessage(ObjectGuid const& senderGuid, std::string
     std::string msg = message;
     std::transform(msg.begin(), msg.end(), msg.begin(), ::tolower);
 
+    // My name
+    // Check if message contains bot names
+    if (Group* group = sender->GetGroup())
+    {
+        for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
+        {
+            if (Player* pMember = itr->getSource())
+            {
+                if (pMember->GetGUIDLow() == playerGuid)
+                    continue;
+
+                if (pMember->AI())
+                {
+                    std::string mName = pMember->GetName();
+                    uint8 mClass = pMember->GetClass();
+                    std::string mNameLower = mName;
+                    std::transform(mNameLower.begin(), mNameLower.end(), mNameLower.begin(), ::tolower);
+
+                    if (msg.find(mNameLower) != std::string::npos)
+                    {
+                        ProcessDirectMessage(senderGuid, message, pMember);
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+
     // Greetings
     if (std::find(greetings.begin(), greetings.end(), msg) != greetings.end())
     {
@@ -251,7 +280,8 @@ void PartyBotChat::ProcessPartyMessage(ObjectGuid const& senderGuid, std::string
 
 
     // Who is the pLeader
-    if (msg.find("who's your daddy") != std::string::npos)
+    if (msg.find("who's your daddy") != std::string::npos || 
+        msg.find("who is your daddy") != std::string::npos)
     {
         if (Group* group = sender->GetGroup())
         {
@@ -293,33 +323,59 @@ void PartyBotChat::ProcessPartyMessage(ObjectGuid const& senderGuid, std::string
         }
     }
 
-
-    // My name
-    // Check if message contains bot names
-    if (Group* group = sender->GetGroup())
-    {
-        for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
+    // Paladin party bots
+    bool const paladinAuraVerb = (msg.find("use") != std::string::npos || msg.find("cast") != std::string::npos);
+    bool const paladinAuraTarget = (msg.find("devotion") != std::string::npos ||
+        msg.find("devo") != std::string::npos ||
+        msg.find("concentration") != std::string::npos ||
+        msg.find("conc") != std::string::npos ||
+        msg.find("sanctity") != std::string::npos ||
+        msg.find("sanc") != std::string::npos ||
+        msg.find("retribution") != std::string::npos ||
+        msg.find("ret") != std::string::npos ||
+        msg.find("valiance") != std::string::npos ||
+        msg.find("val") != std::string::npos);
+    if (paladinAuraVerb && paladinAuraTarget &&
+        (msg.find("paladin") != std::string::npos || 
+         msg.find("pal") != std::string::npos ||
+         msg.find("pally") != std::string::npos ||
+         msg.find("aura") != std::string::npos)
+    ) {
+        Player* respondent = nullptr;
+        std::string chosenAuraName;
+        if (Group* group = sender->GetGroup())
         {
-            if (Player* pMember = itr->getSource())
+            for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
             {
-                if (pMember->GetGUIDLow() == playerGuid)
-                    continue;
-
-                if (pMember->AI())
+                if (Player* pMember = itr->getSource())
                 {
-                    std::string mName = pMember->GetName();
-                    uint8 mClass = pMember->GetClass();
-                    std::string mNameLower = mName;
-                    std::transform(mNameLower.begin(), mNameLower.end(), mNameLower.begin(), ::tolower);
-
-                    if (msg.find(mNameLower) != std::string::npos)
-                        ProcessDirectMessage(senderGuid, message, pMember);
+                    if (pMember->GetGUIDLow() == playerGuid)
+                        continue;
+                    if (pMember->GetClass() != CLASS_PALADIN)
+                        continue;
+                    if (PartyBotAI* pAI = dynamic_cast<PartyBotAI*>(pMember->AI()))
+                    {
+                        std::string thisAura;
+                        if (pAI->TryApplyPaladinAura(msg, &thisAura))
+                        {
+                            if (!respondent)
+                            {
+                                respondent = pMember;
+                                chosenAuraName = std::move(thisAura);
+                            }
+                        }
+                    }
                 }
             }
         }
+        if (respondent && !chosenAuraName.empty())
+        {
+            char reply[192];
+            snprintf(reply, sizeof(reply), "Using %s.", chosenAuraName.c_str());
+            SendPartyChat(reply, respondent);
+        }
     }
 }
-
 
 void PartyBotChat::ProcessDirectMessage(ObjectGuid const& senderGuid, std::string const& message, Player* player)
 {
@@ -357,6 +413,32 @@ void PartyBotChat::ProcessDirectMessage(ObjectGuid const& senderGuid, std::strin
             char message[128];
             snprintf(message, sizeof(message), "Pulling!", sender->GetName());
             SendPartyChat(message, player);
+        }
+    }
+    else if (player->GetClass() == CLASS_PALADIN &&
+             (messageLower.find("use") != std::string::npos || messageLower.find("cast") != std::string::npos))
+    {
+        if (messageLower.find("devotion") != std::string::npos ||
+            messageLower.find("devo") != std::string::npos ||
+            messageLower.find("concentration") != std::string::npos ||
+            messageLower.find("conc") != std::string::npos ||
+            messageLower.find("sanctity") != std::string::npos ||
+            messageLower.find("sanc") != std::string::npos ||
+            messageLower.find("retribution") != std::string::npos ||
+            messageLower.find("ret") != std::string::npos ||
+            messageLower.find("valiance") != std::string::npos ||
+            messageLower.find("val") != std::string::npos)
+        {
+            if (PartyBotAI* pAI = dynamic_cast<PartyBotAI*>(player->AI()))
+            {
+                std::string auraName;
+                if (pAI->TryApplyPaladinAura(messageLower, &auraName))
+                {
+                    char reply[192];
+                    snprintf(reply, sizeof(reply), "Using %s.", auraName.c_str());
+                    SendPartyChat(reply, player);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Paladin bots will now cast blessings based on the class/role of each party member. Greater blessings are preferred (if learned).

Also added support for dynamically changing the paladin's aura via party chat commands.
The following shorthand can be used:
- devo = devotion
- ret = retribution
- sanc = sanctity
- conc = concentration
- val = valiance

<br>

**Party Chat Examples:**
- use devotion aura
- pally use devo
- {name} use retribution
- cast valiance aura
- paladin use concentration



