### PR TITLE
Lavender Dreams Meeting Stones (MC and BWL)

### DIFF
--- a/sql/custom/LavenderDreams/lavender_meeting_stones.sql
+++ b/sql/custom/LavenderDreams/lavender_meeting_stones.sql
@@ -1,0 +1,15 @@
+-- Lavender Dreams - Meeting Stones
+
+INSERT INTO `npc_text` (`ID`, `BroadcastTextID0`, `Probability0`, `BroadcastTextID1`, `Probability1`, `BroadcastTextID2`, `Probability2`, `BroadcastTextID3`, `Probability3`, `BroadcastTextID4`, `Probability4`, `BroadcastTextID5`, `Probability5`, `BroadcastTextID6`, `Probability6`, `BroadcastTextID7`, `Probability7`) VALUES (85000, 85000, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+INSERT INTO `broadcast_text` (`entry`, `male_text`, `female_text`) VALUES (85000, 'Hello $N, what brings you here?', 'Hello $N, what brings you here?');
+
+
+-- Blackrock Depths -> Molten Core
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (8501, 85000, 0, 0);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_broadcast_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `box_broadcast_text`, `condition_id`) VALUES (8501, 0, 5, 'Clear raid lockout for Molten Core', 0, 1, 1, 0, 0, 0, 0, 0, NULL, 0, 0);
+UPDATE `gameobject_template` SET `type` = 2, `data0` = 0, `data1` = 0, `data2` = 3, `data3` = 8501, `data4` = 1, `script_name` = 'lavender_stone' WHERE `entry` = 179584;
+
+-- Blackrock Spire -> Blackwing Lair
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (8502, 85000, 0, 0);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_broadcast_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `box_broadcast_text`, `condition_id`) VALUES (8502, 0, 5, 'Clear raid lockout for Blackwing Lair', 0, 1, 1, 0, 0, 0, 0, 0, NULL, 0, 0);
+UPDATE `gameobject_template` SET `type` = 2, `data0` = 0, `data1` = 0, `data2` = 3, `data3` = 8502, `data4` = 1, `script_name` = 'lavender_stone' WHERE `entry` = 179585;

--- a/src/scripts/CMakeLists.txt
+++ b/src/scripts/CMakeLists.txt
@@ -41,6 +41,7 @@ set (SCRIPTS_SRCS
     custom/custom_creatures.cpp
     custom/event_attack_city.cpp
     custom/gmisland.cpp
+    custom/lavender_stone.cpp
     custom/npc_escort.cpp
     custom/npc_j_eevee.cpp
     eastern_kingdoms/alterac_mountains/alterac_mountains.cpp

--- a/src/scripts/custom/custom.cpp
+++ b/src/scripts/custom/custom.cpp
@@ -16,8 +16,10 @@
 
 #include "scriptPCH.h"
 #include "custom.h"
+#include "lavender_stone.h"
 
 void AddSC_zero_scripts()
 {
     AddSC_custom_creatures();
+    AddSC_lavender_stone();
 }

--- a/src/scripts/custom/lavender_stone.cpp
+++ b/src/scripts/custom/lavender_stone.cpp
@@ -1,0 +1,63 @@
+#include "lavender_stone.h"
+
+bool GossipSelect_lavender_stone(Player* player, GameObject* go, uint32 sender, uint32 action)
+{
+    player->PlayerTalkClass->ClearMenus();
+
+    switch (go->GetEntry())
+    {
+        case MEETING_STONE_BRD:
+            if (ClearLockout(player, MAP_ID_MC))
+                player->GetSession()->SendNotification("Molten Core lockout cleared");
+                player->PSendSysMessage("Molten Core lockout cleared.");
+            break;
+        case MEETING_STONE_BRS:
+            if (ClearLockout(player, MAP_ID_BWL))
+                player->GetSession()->SendNotification("Blackwing Lair lockout cleared");
+                player->PSendSysMessage("Blackwing Lair lockout cleared.");
+            break;
+        default:
+            player->GetSession()->SendNotification("Unknown meeting stone");
+    }
+
+    player->CLOSE_GOSSIP_MENU();
+            
+
+    return false;
+}
+
+bool ClearLockout(Player* player, uint32 mapid)
+{
+    if (!player || !player->IsInWorld())
+        return false;
+
+    uint32 counter = 0;
+    Player::BoundInstancesMap &binds = player->GetBoundInstances();
+    for (Player::BoundInstancesMap::iterator itr = binds.begin(); itr != binds.end();)
+    {
+        if (mapid != itr->first)
+        {
+            ++itr;
+            continue;
+        }
+        if (itr->first != player->GetMapId())
+        {
+            player->UnbindInstance(itr);
+            counter++;
+        }
+        else
+        {
+            ++itr;
+        }
+    }  
+    return true;
+}
+
+
+void AddSC_lavender_stone()
+{
+    Script* pNewScript = new Script;
+    pNewScript->Name = "lavender_stone";
+    pNewScript->pGOGossipSelect = &GossipSelect_lavender_stone;
+    pNewScript->RegisterSelf();
+}

--- a/src/scripts/custom/lavender_stone.h
+++ b/src/scripts/custom/lavender_stone.h
@@ -1,0 +1,16 @@
+#include "scriptPCH.h"
+#include "custom.h"
+
+#define MEETING_STONE_BRD 179584
+#define MEETING_STONE_BRS 179585
+
+#define MAP_ID_MC 409
+#define MAP_ID_BWL 469
+
+
+
+bool GossipSelect_lavender_stone(Player* player, GameObject* go, uint32 sender, uint32 action);
+
+bool ClearLockout(Player* player, uint32 mapid);
+
+void AddSC_lavender_stone();


### PR DESCRIPTION
Introducing the new meeting stone functionality for clearing raid lockouts on demand. Only implemented for MC and BWL at this time (using the Blackrock Depths and Blackrock Spire meeting stones respectively).

**After pulling/merging you will need to run the file `sql/custom/LavenderDreams/lavender_meeting_stones.sql` on your database.**

Also make sure to clear local WDB before launching your client!