### PR TITLE
Make sure tank bots face their target

### DIFF
--- a/sql/custom/LavenderDreams/lavender_meeting_stones.sql
+++ b/sql/custom/LavenderDreams/lavender_meeting_stones.sql
@@ -1,15 +1,16 @@
 -- Lavender Dreams - Meeting Stones
 
-INSERT INTO `npc_text` (`ID`, `BroadcastTextID0`, `Probability0`, `BroadcastTextID1`, `Probability1`, `BroadcastTextID2`, `Probability2`, `BroadcastTextID3`, `Probability3`, `BroadcastTextID4`, `Probability4`, `BroadcastTextID5`, `Probability5`, `BroadcastTextID6`, `Probability6`, `BroadcastTextID7`, `Probability7`) VALUES (85000, 85000, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-INSERT INTO `broadcast_text` (`entry`, `male_text`, `female_text`) VALUES (85000, 'Hello $N, what brings you here?', 'Hello $N, what brings you here?');
+REPLACE INTO `npc_text` (`ID`, `BroadcastTextID0`, `Probability0`, `BroadcastTextID1`, `Probability1`, `BroadcastTextID2`, `Probability2`, `BroadcastTextID3`, `Probability3`, `BroadcastTextID4`, `Probability4`, `BroadcastTextID5`, `Probability5`, `BroadcastTextID6`, `Probability6`, `BroadcastTextID7`, `Probability7`) VALUES (85000, 85000, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+REPLACE INTO `broadcast_text` (`entry`, `male_text`, `female_text`) VALUES (85000, 'Greetings $N, what brings you here?', 'Greetings $N, what brings you here?');
 
 
--- Blackrock Depths -> Molten Core
-INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (8501, 85000, 0, 0);
-INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_broadcast_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `box_broadcast_text`, `condition_id`) VALUES (8501, 0, 5, 'Clear raid lockout for Molten Core', 0, 1, 1, 0, 0, 0, 0, 0, NULL, 0, 0);
-UPDATE `gameobject_template` SET `type` = 2, `data0` = 0, `data1` = 0, `data2` = 3, `data3` = 8501, `data4` = 1, `script_name` = 'lavender_stone' WHERE `entry` = 179584;
+-- Blackrock Depths -> MC & BWL
+UPDATE `gameobject_template` SET `type` = 2, `data0` = 0, `data1` = 0, `data2` = 3, `data3` = 0, `data4` = 1, `script_name` = 'lavender_stone' WHERE `entry` = 179584;
+DELETE FROM `gossip_menu` WHERE `entry` = 8501;
+DELETE FROM `gossip_menu_option` WHERE `menu_id` = 8501;
 
--- Blackrock Spire -> Blackwing Lair
-INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (8502, 85000, 0, 0);
-INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_broadcast_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `box_broadcast_text`, `condition_id`) VALUES (8502, 0, 5, 'Clear raid lockout for Blackwing Lair', 0, 1, 1, 0, 0, 0, 0, 0, NULL, 0, 0);
-UPDATE `gameobject_template` SET `type` = 2, `data0` = 0, `data1` = 0, `data2` = 3, `data3` = 8502, `data4` = 1, `script_name` = 'lavender_stone' WHERE `entry` = 179585;
+-- Remove Blackrock Spire meeting stone
+DELETE FROM `gossip_menu` WHERE `entry` = 8502;
+DELETE FROM `gossip_menu_option` WHERE `menu_id` = 8502;
+DELETE FROM `gameobject_template` WHERE `entry` = 179585;
+DELETE FROM `gameobject` WHERE `id` = 179585;

--- a/src/game/PlayerBots/PartyBotAI.cpp
+++ b/src/game/PlayerBots/PartyBotAI.cpp
@@ -2079,6 +2079,13 @@ void PartyBotAI::UpdateInCombatAI()
                     }
                 }
             }
+
+            // Make sure we are facing the target
+            if (IsValidHostileTarget(pVictim) && !me->HasInArc(pVictim, 2 * M_PI_F / 3) && !me->IsMoving())
+            {
+                me->SetInFront(pVictim);
+                me->SendMovementPacket(MSG_MOVE_SET_FACING, false);
+            }
         }
         else if (m_role == ROLE_MELEE_DPS)
             RepositionMeleeDps();

--- a/src/scripts/custom/lavender_stone.cpp
+++ b/src/scripts/custom/lavender_stone.cpp
@@ -1,29 +1,41 @@
 #include "lavender_stone.h"
 
-bool GossipSelect_lavender_stone(Player* player, GameObject* go, uint32 sender, uint32 action)
+bool GossipHello_lavender_stone(Player* player, GameObject* go)
 {
-    player->PlayerTalkClass->ClearMenus();
+    if (go->GetEntry() != MEETING_STONE_BRD)
+        return false;
 
-    switch (go->GetEntry())
+    player->PlayerTalkClass->ClearMenus();
+    player->ADD_GOSSIP_ITEM(5, "Clear raid lockout for Molten Core", GOSSIP_SENDER_MAIN, GOSSIP_ACT_CLEAR_MC);
+    player->ADD_GOSSIP_ITEM(5, "Clear raid lockout for Blackwing Lair", GOSSIP_SENDER_MAIN, GOSSIP_ACT_CLEAR_BWL);
+    player->SEND_GOSSIP_MENU(85000, go->GetObjectGuid());
+    return true;
+}
+
+bool GossipSelect_lavender_stone(Player* player, GameObject* go, uint32 /*sender*/, uint32 action)
+{
+    if (go->GetEntry() == MEETING_STONE_BRD)
     {
-        case MEETING_STONE_BRD:
+        if (action == GOSSIP_ACT_CLEAR_MC)
+        {
             if (ClearLockout(player, MAP_ID_MC))
+            {
                 player->GetSession()->SendNotification("Molten Core lockout cleared");
                 player->PSendSysMessage("Molten Core lockout cleared.");
-            break;
-        case MEETING_STONE_BRS:
+            }
+        }
+        else if (action == GOSSIP_ACT_CLEAR_BWL)
+        {
             if (ClearLockout(player, MAP_ID_BWL))
+            {
                 player->GetSession()->SendNotification("Blackwing Lair lockout cleared");
                 player->PSendSysMessage("Blackwing Lair lockout cleared.");
-            break;
-        default:
-            player->GetSession()->SendNotification("Unknown meeting stone");
+            }
+        }
     }
 
     player->CLOSE_GOSSIP_MENU();
-            
-
-    return false;
+    return true;
 }
 
 bool ClearLockout(Player* player, uint32 mapid)
@@ -58,6 +70,7 @@ void AddSC_lavender_stone()
 {
     Script* pNewScript = new Script;
     pNewScript->Name = "lavender_stone";
+    pNewScript->pGOGossipHello = &GossipHello_lavender_stone;
     pNewScript->pGOGossipSelect = &GossipSelect_lavender_stone;
     pNewScript->RegisterSelf();
 }

--- a/src/scripts/custom/lavender_stone.h
+++ b/src/scripts/custom/lavender_stone.h
@@ -7,7 +7,11 @@
 #define MAP_ID_MC 409
 #define MAP_ID_BWL 469
 
+uint32 const GOSSIP_ACT_CLEAR_MC  = GOSSIP_ACTION_INFO_DEF;
+uint32 const GOSSIP_ACT_CLEAR_BWL = GOSSIP_ACTION_INFO_DEF + 1;
 
+
+bool GossipHello_lavender_stone(Player* player, GameObject* go);
 
 bool GossipSelect_lavender_stone(Player* player, GameObject* go, uint32 sender, uint32 action);
 


### PR DESCRIPTION
Tank bots will now make sure their current target is within a 120-degree arc in front of them to prevent "getting stuck" if it were to move outside their attack radius
